### PR TITLE
experiment: add gumbel softmax

### DIFF
--- a/aphrodite/modeling/models/mixtral.py
+++ b/aphrodite/modeling/models/mixtral.py
@@ -155,7 +155,8 @@ class MixtralDecoderLayer(nn.Module):
         self.block_sparse_moe = MoE(num_experts=config.num_local_experts,
                                     top_k=config.num_experts_per_tok,
                                     hidden_size=config.hidden_size,
-                                    intermediate_size=config.intermediate_size)
+                                    intermediate_size=config.intermediate_size,
+                                    temperature=config.temperature)
         self.input_layernorm = RMSNorm(config.hidden_size,
                                        eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(config.hidden_size,


### PR DESCRIPTION
This PR is an attempt at replacing the regular softmax for MoE gating with a [Gumbel-Softmax](https://arxiv.org/abs/1611.01144) function instead. 

The paper [Approximating Two-Layer Feedforward Networks for Efficient Transformers](https://arxiv.org/abs/2310.10837) suggests that softmax may not be ideal for gating mechanism, arguing that it's too competitive and may result in some experts being disproportionately used in the selection process.

This PR is an experiment to see if replacing Softmax with Gumbel-Softmax can help with diversifying the expert selection process. By adding noise to the logits, the selection process will hopefully introduce enough fluctuation to the softmax probabilities that if one expert has a slightly higher logit value compared to another one, it won't be chosen *every time*.
 
I've added a new parameter, `temperature`, to control the amount of randomness added. This will need to be inserted in the model's config.json.