### PR TITLE
feat: add perplexity example

### DIFF
--- a/examples/perplexity.py
+++ b/examples/perplexity.py
@@ -1,0 +1,51 @@
+import numpy as np
+from datasets import load_dataset
+from transformers import AutoTokenizer
+from aphrodite import LLM, SamplingParams
+
+# Load the wikitext2 dataset.
+dataset = load_dataset('wikitext', 'wikitext-2-raw-v1')
+
+# Get the first 2000 elements from the 'train' split.
+prompts = dataset['train']['text'][:2000]
+
+model_id = "mistralai/Mistral-7B-Instruct-v0.2"
+# Create a tokenizer.
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+# Tokenize the prompts and discard or truncate any prompts longer than 2048 tokens.
+tokenized_prompts = [tokenizer.encode(prompt, truncation=True,
+                                      max_length=4096) for prompt in prompts]
+
+# Detokenize the prompts.
+detokenized_prompts = [tokenizer.decode(tokens
+                                        ) for tokens in tokenized_prompts]
+
+# Create a sampling params object.
+sampling_params = SamplingParams(
+    temperature=0.0,
+    ignore_eos=True,
+    max_tokens=10,
+    skip_special_tokens=False,
+    spaces_between_special_tokens=False,
+    logprobs=1,
+    prompt_logprobs=1,
+)
+
+# Create an LLM.
+llm = LLM(model=model_id)
+
+# Generate texts from the detokenized prompts.
+outputs = llm.generate(detokenized_prompts, sampling_params)
+
+# Calculate the perplexity.
+all_logprobs = []
+for output in outputs:
+    all_logprobs.extend([next(iter(lp.values())) for lp in output.prompt_logprobs[1:]])
+
+all_logprobs = np.array([lp.logprob for lp in all_logprobs])
+# NOTE: we need to divide by 2 to match the perplexity results
+# for the same model on llama.cpp. I'm unsure if this
+# approach to ppx measurement is correct.
+perplexity = (np.exp(-all_logprobs.mean())) / 2
+print(f"Perplexity: {perplexity}")


### PR DESCRIPTION
This PR adds an example to calculate model perplexity, this approach performs it by using `prompt_logprobs`:

- Generate text using a dataset and extract 1 prompt logprob per token.
- Calculate the mean of the logprobs.
- Calculate the exponent of the *negative* mean of the logprobs.
- Divide the result by 2.

The last step should technically be unneeded, but to match the perplexity results from llama.cpp, we seem to need the division by two. It still seems unreliable, as Llama-2 7B shows a lower ppx than Mistral 7B, and FP8 KV Cache doesn't change ppx at all.