### PR TITLE
fix: dynamic temperature scaling in multi-node inference

### DIFF
--- a/aphrodite/modeling/layers/sampler.py
+++ b/aphrodite/modeling/layers/sampler.py
@@ -403,7 +403,7 @@ def _apply_temperature(
     dynatemp_exps: torch.Tensor,
 ) -> torch.Tensor:
     dynatemp_mask = torch.logical_or(dynatemp_mins > 0, dynatemp_maxs > 0)
-    
+
     # Check if dynatemp_mask is not empty
     if dynatemp_mask.any():
         dynatemp_mins = dynatemp_mins[dynatemp_mask]
@@ -428,7 +428,7 @@ def _apply_temperature(
 
     while temperatures.dim() < logits.dim():
         temperatures = temperatures.unsqueeze(-1)
-    
+
     logits = logits.div(temperatures)
     return logits
 


### PR DESCRIPTION
Seems like our current implementation has an issue:

```
                    dynatemp_logits = logits[dynatemp_mask]
ERROR:        |                       ~~~~~~^^^^^^^^^^^^^^^
ERROR:        | IndexError: The shape of the mask [1] at index 0 does not match the shape of the indexed tensor [0, 128256] at index 0
```