### PR TITLE
chore: upgrade to torch 2.8.0, cuda 12.8, python 3.13

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,9 @@ jobs:
       fail-fast: false
       matrix:
           os: ['ubuntu-22.04']
-          python-version: ['3.12']
-          pytorch-version: ['2.6.0']  # Must be the most recent version that meets requirements/cuda.txt.
-          cuda-version: ['12.4']
+          python-version: ['3.13']
+          pytorch-version: ['2.8.0']  # Must be the most recent version that meets requirements/cuda.txt.
+          cuda-version: ['12.8']
 
     steps:
       - name: Checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ install(CODE "set(CMAKE_INSTALL_LOCAL_ONLY TRUE)" ALL_COMPONENTS)
 # Supported python versions.  These versions will be searched in order, the
 # first match will be selected.  These should be kept in sync with setup.py.
 #
-set(PYTHON_SUPPORTED_VERSIONS "3.9" "3.10" "3.11" "3.12")
+set(PYTHON_SUPPORTED_VERSIONS "3.9" "3.10" "3.11" "3.12" "3.13")
 
 # Supported AMD GPU architectures.
 set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1200;gfx1201")
@@ -46,7 +46,7 @@ set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1
 # requirements.txt files and should be kept consistent.  The ROCm torch
 # versions are derived from docker/Dockerfile.rocm
 #
-set(TORCH_SUPPORTED_VERSION_CUDA "2.7.1")
+set(TORCH_SUPPORTED_VERSION_CUDA "2.8.0")
 set(TORCH_SUPPORTED_VERSION_ROCM "2.7.0")
 
 #

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This will pull the Aphrodite Engine image (~8GiB download), and launch the engin
 ## Requirements
 
 - Operating System: Linux, Windows (Needs building from source)
-- Python: 3.9 to 3.12
+- Python: 3.9 to 3.13
 
 #### Build Requirements:
 - CUDA >= 12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 # Should be mirrored in requirements/build.txt
 requires = [
-    "cmake>=3.26.1",
+    "cmake>=3.31.6",
     "ninja",
     "packaging>=24.2",
     "setuptools>=77.0.3,<80.0.0",
     "setuptools-scm>=8.0",
-    "torch == 2.7.1",
+    "torch == 2.8.0",
     "wheel",
     "jinja2",
 ]
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,10 +1,10 @@
 # Should be mirrored in pyproject.toml
-cmake>=3.26.1
+cmake>=3.31.6
 ninja
 packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
-torch==2.7.1
+torch==2.8.0
 wheel
 jinja2>=3.1.6
 regex

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -6,9 +6,9 @@ numba == 0.61.2; python_version > '3.9'
 
 # Dependencies for NVIDIA GPUs
 ray[cgraph]>=2.48.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
-torch==2.7.1
-torchaudio==2.7.1
+torch==2.8.0
+torchaudio==2.8.0
 # These must be updated alongside torch
-torchvision==0.22.1 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
+torchvision==0.23.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 # https://github.com/facebookresearch/xformers/releases/tag/v0.0.31
-xformers==0.0.31; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.7
+#xformers==0.0.32.dev1073; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch >= 2.7


### PR DESCRIPTION
Deprecating xformers as an attention backend, too. FlashInfer supports Turing cards so it's fine I think.