### PR TITLE
feat: add support for fully-trained lm_head and embed_tokens modules in LoRA adapters

### DIFF
--- a/aphrodite/config/__init__.py
+++ b/aphrodite/config/__init__.py
@@ -2530,6 +2530,10 @@ class LoRAConfig:
     per prompt. When run in offline mode, the lora IDs for n modalities
     will be automatically assigned to 1-n with the names of the modalities
     in alphabetic order."""
+    enable_lora_modules_to_save: bool = False
+    """
+    Enable handling of fully-trained lm_head and embed_tokens modules.
+    """
     bias_enabled: bool = False
     """Enable bias for LoRA adapters."""
 

--- a/aphrodite/engine/args_tools.py
+++ b/aphrodite/engine/args_tools.py
@@ -351,6 +351,7 @@ class EngineArgs:
     enable_lora_bias: bool = LoRAConfig.bias_enabled
     max_loras: int = LoRAConfig.max_loras
     max_lora_rank: int = LoRAConfig.max_lora_rank
+    enable_lora_modules_to_save: bool = LoRAConfig.enable_lora_modules_to_save
     default_mm_loras: Optional[Dict[str, str]] = \
         LoRAConfig.default_mm_loras
     fully_sharded_loras: bool = LoRAConfig.fully_sharded_loras
@@ -737,6 +738,8 @@ class EngineArgs:
         lora_group.add_argument("--max-loras", **lora_kwargs["max_loras"])
         lora_group.add_argument("--max-lora-rank",
                                 **lora_kwargs["max_lora_rank"])
+        lora_group.add_argument("--enable-lora-modules-to-save",
+                                **lora_kwargs["enable_lora_modules_to_save"])
         lora_group.add_argument("--lora-extra-vocab-size",
                                 **lora_kwargs["lora_extra_vocab_size"])
         lora_group.add_argument(
@@ -1325,6 +1328,7 @@ class EngineArgs:
         lora_config = LoRAConfig(
             bias_enabled=self.enable_lora_bias,
             max_lora_rank=self.max_lora_rank,
+            enable_lora_modules_to_save=self.enable_lora_modules_to_save,
             max_loras=self.max_loras,
             default_mm_loras=self.default_mm_loras,
             fully_sharded_loras=self.fully_sharded_loras,

--- a/aphrodite/lora/layers.py
+++ b/aphrodite/lora/layers.py
@@ -25,7 +25,7 @@ from aphrodite.modeling.layers.linear import (ColumnParallelLinear, LinearBase,
 # yapf: enable
 from aphrodite.modeling.layers.logits_processor import LogitsProcessor
 from aphrodite.modeling.layers.vocab_parallel_embedding import (
-    VocabParallelEmbedding)
+    ParallelLMHead, VocabParallelEmbedding)
 from aphrodite.platforms import current_platform
 
 if TYPE_CHECKING:
@@ -104,7 +104,8 @@ class BaseLayerWithLoRA(nn.Module):
     def set_lora(
         self,
         index: int,
-        lora_a: torch.Tensor,
+        lora_a: Optional[
+            torch.Tensor],  # lora_a=None in case of modules_to_save
         lora_b: torch.Tensor,
         embeddings_tensor: Optional[torch.Tensor],
         bias: Optional[torch.Tensor] = None,
@@ -276,6 +277,8 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
         packed_modules_list: list,
         model_config: Optional[PretrainedConfig],
     ) -> bool:
+        if lora_config.enable_lora_modules_to_save:
+            return False
         return type(source_layer) is VocabParallelEmbedding
 
     @property
@@ -758,6 +761,7 @@ class QKVParallelLinearWithLoRA(ColumnParallelLinearWithLoRA):
 
     def __init__(self, base_layer: QKVParallelLinear) -> None:
         super().__init__(base_layer)
+        self.tp_size = get_tensor_model_parallel_world_size()
         self.q_proj_total_size = (self.base_layer.total_num_heads *
                                   self.base_layer.head_size)
         self.q_proj_shard_size = (self.base_layer.num_heads *
@@ -1186,3 +1190,147 @@ class LogitsProcessorWithLoRA(BaseLayerWithLoRA):
     ) -> bool:
         # Special handling for the LogitsProcessor.
         return False
+
+
+class ModulesToSaveWrapper(BaseLayerWithLoRA):
+    """
+    LoRA wrapper for lm_head layer, inspired by ModulesToSaveWrapper from peft
+    contains the copy of base_layer but with replaced weights
+    overrides getattr in a such way that 
+    returns the attribute of this base_layer copy,
+    so clients can call ModuleToSave exactly as base_layer module
+    
+    Args:
+        base_layer: layer to replace by Wrapper: 
+          VocabParallelEmbedding (for embed_tokens)
+          or ParallelLMHead (for lm_head)
+    """
+
+    implemented_layers = ['lm_head', 'embed_tokens']
+
+    def __init__(
+            self, base_layer: Union[VocabParallelEmbedding,
+                                    ParallelLMHead]) -> None:
+        super().__init__()
+        self.base_layer = base_layer
+        self.device = _get_lora_device(self.base_layer)
+
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.tp_rank = get_tensor_model_parallel_rank()
+
+        self._org_vocab_size = None
+
+        self._base_layer_replacement = None
+
+        self._base_layer_kwargs = {
+            "num_embeddings": base_layer.num_embeddings,
+            "embedding_dim": base_layer.embedding_dim
+        }
+
+    @property
+    def padded_vocab_size(self):
+        # number of embeddings with paddings and with max_lora_extra_vocab_size
+        return self.base_layer.num_embeddings_padded
+
+    @property
+    def org_vocab_size(self):
+        # vocab size with maximal amount of extra symbols added by loras
+        return self._org_vocab_size
+
+    @property
+    def embedding_dim(self):
+        return self.base_layer.embedding_dim
+
+    @property
+    def bias(self):
+        return self.base_layer.bias
+
+    @property
+    def linear_method(self):
+        if self.punica_wrapper.no_lora:
+            return self.base_layer.linear_method
+        return self
+
+    @property
+    def weight(self):
+        return self.base_layer.weight
+
+    def apply(self, lm_head: 'ModulesToSaveWrapper',
+              hidden_states: torch.Tensor,
+              bias: Optional[torch.Tensor]) -> torch.Tensor:
+
+        assert isinstance(self.base_layer, ParallelLMHead)
+
+        logits = self.punica_wrapper.bgmv_sample(hidden_states,
+                                                 self._lora_tensors,
+                                                 self.base_layer.weight)
+
+        if bias is not None:
+            logits += bias
+
+        return logits
+
+    def embedding(self, embed_tokens: 'ModulesToSaveWrapper',
+                  masked_input: torch.LongTensor):
+        assert isinstance(self.base_layer, VocabParallelEmbedding)
+        embeddings = self.punica_wrapper.bgmv_embedding(
+            masked_input, self._lora_tensors, self.base_layer.weight)
+        return embeddings
+
+    def create_lora_weights(
+        self,
+        max_loras: int,
+        lora_config: LoRAConfig,
+        model_config: Optional[PretrainedConfig] = None,
+    ) -> None:
+
+        self.dtype = lora_config.lora_dtype
+
+        self._orig_vocab_size = (self.base_layer.org_vocab_size +
+                                 lora_config.lora_extra_vocab_size)
+
+        # lora_tensors - lm_head tensors in case of ParallelLMHead base
+        # or embed_tokens tensors in case of VocabParallelEmbedding
+        self._lora_tensors = torch.zeros(
+            (max_loras, self._orig_vocab_size, self.base_layer.embedding_dim),
+            dtype=self.base_layer.weight.dtype,
+            device=self.device,
+        )
+        for index in range(max_loras):
+            self.reset_lora(index)
+
+    def reset_lora(self, index: int):
+        weights = self.base_layer.weight
+        self._lora_tensors[index, :weights.shape[0], :weights.shape[1]].copy_(
+            weights, non_blocking=True)
+
+    def set_lora(
+        self,
+        index: int,
+        lora_a: Optional[torch.Tensor],
+        lora_b: torch.Tensor,
+        embeddings_tensor: Optional[torch.Tensor],
+        bias: Optional[torch.Tensor] = None,
+    ):
+        assert lora_a is None
+        assert embeddings_tensor is None
+        assert bias is None, "bias is not implemented for ModulesToSave"
+
+        self.reset_lora(index)
+        self._lora_tensors[index, :lora_b.shape[0], :lora_b.shape[1]].copy_(
+            lora_b, non_blocking=True)
+
+    def forward(self, *args, **kwargs):
+        return type(self.base_layer).forward(self, *args, **kwargs)
+
+    @classmethod
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: Optional[PretrainedConfig],
+    ) -> bool:
+        if not lora_config.enable_lora_modules_to_save:
+            return False
+        return type(source_layer) in (ParallelLMHead, VocabParallelEmbedding)

--- a/aphrodite/lora/lora.py
+++ b/aphrodite/lora/lora.py
@@ -14,14 +14,21 @@ class LoRALayerWeights:
     def __init__(
         self,
         module_name: str,
-        rank: int,
+        rank: Optional[int],
         lora_alpha: int,
-        lora_a: torch.Tensor,
+        lora_a: Optional[torch.Tensor],
         lora_b: torch.Tensor,
         bias: Optional[torch.Tensor] = None,
         embeddings_tensor: Optional[torch.Tensor] = None,
         scaling: Optional[float] = None,
     ) -> None:
+        """
+        rank == None means that we have full rank tensors (ModulesToSave) in
+        this case:
+        lora_a=None
+        lora_b=full rank tensor
+        scaling=None
+        """
         self.module_name = module_name
         self.rank = rank
         self.lora_alpha = lora_alpha
@@ -30,22 +37,26 @@ class LoRALayerWeights:
         self.bias = bias
         self.embeddings_tensor = embeddings_tensor
 
-        if scaling is None:
+        self.scaling = scaling
+
+        if (scaling is None) and (self.rank is not None):
             self.scaling = self.lora_alpha / self.rank
-        else:
-            self.scaling = scaling
 
     def optimize(self) -> "LoRALayerWeights":
         """Optimize the LoRA by merging the scaling into lora_b."""
         if self.scaling == 1:
             return self
-        self.lora_b *= self.scaling
+        if self.scaling is not None:
+            self.lora_b *= self.scaling
         self.scaling = 1
         return self
 
     @property
     def input_dim(self) -> int:
-        return self.lora_a.shape[0]
+        if self.lora_a is not None:
+            return self.lora_a.shape[0]
+
+        return self.lora_b.shape[0]
 
     @property
     def output_dim(self) -> int:
@@ -77,34 +88,43 @@ class LoRALayerWeights:
             module_name: str,
             input_dim: int,
             output_dim: int,
-            rank: int,
+            rank: Optional[int],
             dtype: torch.dtype,
             device: torch.types.Device,
             embeddings_tensor_dim: Optional[int] = None,
             bias_enabled: Optional[bool] = False) -> "LoRALayerWeights":
         pin_memory = str(device) == "cpu" and is_pin_memory_available()
-        lora_a = torch.zeros([input_dim, rank],
-                             dtype=dtype,
-                             device=device,
-                             pin_memory=pin_memory)
-        lora_b = torch.zeros([rank, output_dim],
-                             dtype=dtype,
-                             device=device,
-                             pin_memory=pin_memory)
-        if bias_enabled:
-            bias = torch.zeros([output_dim],
-                               dtype=dtype,
-                               device=device,
-                               pin_memory=pin_memory)
-        else:
+        if rank is None:
+            lora_a = None
+            lora_b = torch.zeros([input_dim, output_dim],
+                                 dtype=dtype,
+                                 device=device,
+                                 pin_memory=pin_memory)
+            embeddings_tensor = None
             bias = None
+        else:
+            lora_a = torch.zeros([input_dim, rank],
+                                 dtype=dtype,
+                                 device=device,
+                                 pin_memory=pin_memory)
+            lora_b = torch.zeros([rank, output_dim],
+                                 dtype=dtype,
+                                 device=device,
+                                 pin_memory=pin_memory)
+            if bias_enabled:
+                bias = torch.zeros([output_dim],
+                                   dtype=dtype,
+                                   device=device,
+                                   pin_memory=pin_memory)
+            else:
+                bias = None
 
-        embeddings_tensor = torch.rand(
-            10,
-            embeddings_tensor_dim,
-            dtype=dtype,
-            device=device,
-            pin_memory=pin_memory) if embeddings_tensor_dim else None
+            embeddings_tensor = torch.rand(
+                10,
+                embeddings_tensor_dim,
+                dtype=dtype,
+                device=device,
+                pin_memory=pin_memory) if embeddings_tensor_dim else None
         return cls(
             module_name,
             rank=rank,
@@ -115,6 +135,13 @@ class LoRALayerWeights:
             embeddings_tensor=embeddings_tensor,
         )
 
+    def lora_a_pin_memory(self):
+        if self.lora_a is not None:
+            self.lora_a = self.lora_a.pin_memory()
+
+    def lora_b_pin_memory(self):
+        self.lora_b = self.lora_b.pin_memory()
+
 
 class PackedLoRALayerWeights(LoRALayerWeights):
     """LoRA used for packed layers (eg. qkv_proj)."""
@@ -122,7 +149,7 @@ class PackedLoRALayerWeights(LoRALayerWeights):
     def __init__(
         self,
         module_name: str,
-        rank: int,
+        rank: Optional[int],
         lora_alphas: list[Optional[int]],
         lora_a: list[Optional[torch.Tensor]],
         lora_b: list[Optional[torch.Tensor]],
@@ -140,7 +167,7 @@ class PackedLoRALayerWeights(LoRALayerWeights):
             embeddings_tensor=None,
         )
         self.lora_alphas = lora_alphas
-        if scaling is None:
+        if (scaling is None) and (self.rank is not None):
             self.scaling = [  # type: ignore
                 lora_alpha / self.rank  # type: ignore # noqa
                 for lora_alpha in self.lora_alphas

--- a/aphrodite/lora/ops/triton_ops/__init__.py
+++ b/aphrodite/lora/ops/triton_ops/__init__.py
@@ -1,8 +1,12 @@
+from aphrodite.lora.ops.triton_ops.bgmv_embed import bgmv_embed
+from aphrodite.lora.ops.triton_ops.bgmv_sample import bgmv_sample
 from aphrodite.lora.ops.triton_ops.lora_expand_op import lora_expand
 from aphrodite.lora.ops.triton_ops.lora_kernel_metadata import LoRAKernelMeta
 from aphrodite.lora.ops.triton_ops.lora_shrink_op import lora_shrink
 
 __all__ = [
+    "bgmv_embed",
+    "bgmv_sample",
     "lora_expand",
     "lora_shrink",
     "LoRAKernelMeta",

--- a/aphrodite/lora/ops/triton_ops/bgmv_embed.py
+++ b/aphrodite/lora/ops/triton_ops/bgmv_embed.py
@@ -1,0 +1,162 @@
+import torch
+
+from aphrodite.triton_utils import tl, triton
+from aphrodite.utils import direct_register_custom_op
+
+from .utils import get_lora_op_configs
+
+
+def next_power_of_2(n: int) -> int:
+    """
+    Returns the smallest power of two >= n
+    """
+    return 1 << ((n - 1).bit_length())
+
+
+@triton.jit
+def _bgmv_embed_kernel(
+    tokens,  # pointer to tokens array
+    embed_tokens_all,  # pointer to embedded tokens - all
+    embed_tokens_base,  # pointer to embedded tokens - base
+    token_indices,  # pointer to token indices
+    embeddings,  # pointer to output embeddings
+    num_tokens,  # number of tokens
+    REAL_HIDDEN_DIM: tl.constexpr,  # actual hidden dimension
+    HIDDEN_DIM_P2: tl.constexpr,  # hidden dimension padded up to power of 2
+    VOCAB_SIZE: tl.constexpr,  # vocabulary size
+    BLOCK_N: tl.constexpr  # block size (number of tokens per block)
+):
+    # Calculate the block offset for this program instance
+    start_idx = tl.program_id(0) * BLOCK_N
+
+    # Offsets for token IDs in this block
+    offs_n = start_idx + tl.arange(0, BLOCK_N)
+    mask_n = offs_n < num_tokens  # valid token mask
+
+    # Read token indices and LoRA indices
+    cur_tokens = tl.load(tokens + offs_n, mask=mask_n, other=0)
+    lora_index = tl.load(token_indices + offs_n, mask=mask_n, other=-1)
+
+    #
+    # For the hidden dimension, we tile with HIDDEN_DIM_P2 threads
+    # but we only load/store up to REAL_HIDDEN_DIM columns.
+    #
+    hidden_range = tl.arange(0, HIDDEN_DIM_P2)  # [0..HIDDEN_DIM_P2)
+    mask_h = hidden_range < REAL_HIDDEN_DIM  # extra mask for columns
+    mask = mask_n[:,
+                  None] & mask_h[None, :]  # combined mask (tokens & columns)
+
+    # ------------------------------------------------
+    # 1) Load embeddings from embed_tokens_base
+    # ------------------------------------------------
+    # embed_tokens_base is laid out as [vocab_size, REAL_HIDDEN_DIM]
+    # offset for row = cur_tokens[i], col = hidden_range
+    offsets_base = cur_tokens[:,
+                              None] * REAL_HIDDEN_DIM + hidden_range[None, :]
+    # masked load (don’t load if token is invalid or col >= REAL_HIDDEN_DIM)
+    embeddings_base = tl.load(embed_tokens_base + offsets_base,
+                              mask=mask,
+                              other=0.0)
+
+    # Start our final block from the base embeddings
+    embeddings_block = embeddings_base
+
+    # ------------------------------------------------
+    # 2) For tokens with a valid LoRA index, load from embed_tokens_all
+    # ------------------------------------------------
+    # mask for tokens that actually have a LoRA index
+    mask_all = (lora_index != -1) & mask_n
+
+    # embed_tokens_all is shaped [num_loras, vocab_size, REAL_HIDDEN_DIM]
+    # We flatten it as if:
+    #   “base offset” = lora_index * (vocab_size * REAL_HIDDEN_DIM)
+    #   plus offset for the token row
+    #   plus hidden_range
+    #
+    base_offsets_all = tl.where(mask_all,
+                                lora_index * VOCAB_SIZE * REAL_HIDDEN_DIM, 0)
+    # tile offsets expression
+    offsets_all = base_offsets_all[:, None] + offsets_base
+    # masked load
+    embeddings_all = tl.load(embed_tokens_all + offsets_all,
+                             mask=mask,
+                             other=0.0)
+    # Overwrite wherever lora_index != -1
+    #   Note: mask_all[:, None] is only for the “token” axis;
+    # we still need mask_h for columns
+    combined_mask_all = mask_all[:, None] & mask_h[None, :]
+    embeddings_block = tl.where(combined_mask_all, embeddings_all,
+                                embeddings_block)
+
+    # ------------------------------------------------
+    # 3) Store result to output
+    # ------------------------------------------------
+    # embeddings is shaped [num_tokens, REAL_HIDDEN_DIM]
+    # offset for row = offs_n[i], col = hidden_range
+    output_offsets = offs_n[:, None] * REAL_HIDDEN_DIM + hidden_range[None, :]
+    # same combined mask needed for storing
+    tl.store(embeddings + output_offsets, embeddings_block, mask=mask)
+
+
+@torch.inference_mode()
+def _bgmv_embed(
+    tokens: torch.Tensor,
+    embed_tokens_all: torch.Tensor,
+    embed_tokens_base: torch.Tensor,
+    token_indices: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Args:
+        tokens:           [num_tokens] int64
+        embed_tokens_all: [num_loras, vocab_size, hidden_dim]
+        embed_tokens_base:[vocab_size, hidden_dim]
+        token_indices:    [num_tokens]  (LoRA indices, -1 means no LoRA)
+    
+    Returns:
+        embeddings:       [num_tokens, hidden_dim]
+    """
+    assert embed_tokens_all.dtype == embed_tokens_base.dtype
+    assert tokens.dtype == torch.int64
+    assert token_indices.dtype == torch.int64
+
+    assert embed_tokens_base.is_contiguous()
+    assert embed_tokens_all.is_contiguous()
+
+    vocab_size, real_hidden_dim = embed_tokens_all.shape[-2:]
+    num_tokens = tokens.shape[0]
+    embeddings = torch.zeros((num_tokens, real_hidden_dim),
+                             dtype=embed_tokens_all.dtype,
+                             device=embed_tokens_all.device)
+
+    # Triton requires a power-of-2 block-size dimension for performance
+    hidden_dim_p2 = next_power_of_2(real_hidden_dim)
+
+    # Adjust your config call so that Triton blocks use hidden_dim_p2
+    config = get_lora_op_configs("embed", num_tokens, hidden_dim_p2)
+    # config typically returns a dict, e.g. {"BLOCK_N": some_value}
+
+    # Kernel launch
+    grid = lambda meta: (triton.cdiv(num_tokens, meta['BLOCK_N']), )
+    _bgmv_embed_kernel[grid](
+        tokens,
+        embed_tokens_all,
+        embed_tokens_base,
+        token_indices,
+        embeddings,
+        num_tokens,
+        REAL_HIDDEN_DIM=real_hidden_dim,
+        HIDDEN_DIM_P2=hidden_dim_p2,
+        VOCAB_SIZE=vocab_size,
+        **config,
+    )
+    return embeddings
+
+
+try:
+    direct_register_custom_op(op_name="bgmv_embed",
+                              op_func=_bgmv_embed,
+                              mutates_args=[],
+                              fake_impl=None)
+    bgmv_embed = torch.ops.aphrodite.bgmv_embed
+except AttributeError:
+    bgmv_embed = _bgmv_embed

--- a/aphrodite/lora/ops/triton_ops/bgmv_sample.py
+++ b/aphrodite/lora/ops/triton_ops/bgmv_sample.py
@@ -1,0 +1,143 @@
+import torch
+
+from aphrodite.triton_utils import tl, triton
+from aphrodite.utils import direct_register_custom_op
+
+from .utils import get_lora_op_configs
+
+
+def next_power_of_two(n: int) -> int:
+    """
+    Returns the smallest power-of-two integer >= n.
+    For example:
+    - n=1 -> 1
+    - n=3 -> 4
+    - n=5 -> 8
+    - n=8 -> 8
+    - n=9 -> 16
+    """
+    return 1 << ((n - 1).bit_length())
+
+
+@triton.jit
+def _bgmv_sample_kernel_arbitrary(
+        hidden_state_ptr,  # float32[ ..., HIDDEN_DIM ]
+        lm_heads_all_ptr,  # float32[ VOCAB_SIZE * HIDDEN_DIM_P2 * num_lora? ]
+        lm_head_base_ptr,  # float32[ VOCAB_SIZE * HIDDEN_DIM_P2 ]
+        logits_ptr,  # float32[ ..., VOCAB_SIZE ]
+        sampling_indices_tensor_ptr,  # int32[ ... ]
+        HIDDEN_DIM: tl.constexpr,
+        HIDDEN_DIM_P2: tl.constexpr,  # internal power-of-two dimension
+        VOCAB_SIZE: tl.constexpr,
+        BLOCK_N: tl.constexpr):
+    """
+    A Triton kernel that:
+    - Rounds HIDDEN_DIM up to HIDDEN_DIM_P2 (a power of two)
+    - Applies a mask for the out-of-bounds region (if any)
+    """
+
+    # Program IDs for parallelization
+    cur_token = tl.program_id(axis=0)
+    logits_start_idx = tl.program_id(axis=1) * BLOCK_N
+
+    # Read which LoRA index to use for this token
+    lora_index = tl.load(sampling_indices_tensor_ptr + cur_token)
+
+    # Create index range [0..HIDDEN_DIM_P2)
+    offsets_embed = tl.arange(0, HIDDEN_DIM_P2)
+    # Boolean mask to disable out-of-range indices
+    mask = offsets_embed < HIDDEN_DIM
+
+    # Load hidden_state (size = HIDDEN_DIM_P2),
+    # using a mask to skip invalid positions
+    hidden_ptr = hidden_state_ptr + cur_token * HIDDEN_DIM + offsets_embed
+    hidden_state = tl.load(hidden_ptr, mask=mask, other=0.0)
+    # Expand dims so we can do [Block_N, HIDDEN_DIM_P2] * [1, HIDDEN_DIM_P2]
+    hidden_state = hidden_state.expand_dims(0)
+
+    # Offsets in the logits dimension
+    offsets_logits = logits_start_idx + tl.arange(0, BLOCK_N)
+
+    # Compute memory offsets for loading weights
+    # We scale by HIDDEN_DIM_P2 because that's the *internally used* dimension
+    offset_base_layer = offsets_embed[None, :] + (offsets_logits[:, None] *
+                                                  HIDDEN_DIM)
+    offset_lora = lora_index * (VOCAB_SIZE * HIDDEN_DIM) + offset_base_layer
+
+    # Depending on lora_index, load from lm_head_base_ptr or lm_heads_all_ptr
+    if lora_index == -1:
+        weights = tl.load(lm_head_base_ptr + offset_base_layer,
+                          mask=mask[None, :],
+                          other=0.0)
+    else:
+        weights = tl.load(lm_heads_all_ptr + offset_lora,
+                          mask=mask[None, :],
+                          other=0.0)
+
+    # Compute logits by summation over the masked dimension
+    logits = tl.sum(weights * hidden_state, axis=1)
+
+    # Store the result
+    tl.store(logits_ptr + cur_token * VOCAB_SIZE + offsets_logits, logits)
+
+
+@torch.inference_mode()
+def _bgmv_sample(
+    hidden_state: torch.Tensor,
+    lm_heads_all: torch.Tensor,
+    lm_head_base: torch.Tensor,
+    sampling_indices_tensor: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Args:
+        hidden_state - [num_tokens, hidden_dim]
+        lm_heads_all - [num_loras, vocab_size, hidden_dim]
+        sampling_indices_tensor - [num_tokens] - indexes from 0 to num_loras-1
+    """
+    assert hidden_state.dtype == lm_heads_all.dtype
+    assert hidden_state.size(-1) == lm_heads_all.size(-1)
+    assert hidden_state.is_contiguous()
+    assert lm_heads_all.is_contiguous()
+
+    vocab_size = lm_heads_all.shape[-2]
+    logits = torch.zeros((hidden_state.size(0), vocab_size),
+                         dtype=hidden_state.dtype,
+                         device=hidden_state.device)
+
+    num_tokens = sampling_indices_tensor.shape[0]
+    hidden_dim = hidden_state.shape[-1]
+
+    grid = lambda meta: (num_tokens, triton.cdiv(vocab_size, meta['BLOCK_N']))
+
+    config = get_lora_op_configs("sample", num_tokens, hidden_dim)
+
+    assert num_tokens / config['BLOCK_N'] < 65535, (
+        "increase BLOCK_N,"
+        "triton can not handle grid size larger 2**31-1")
+
+    HIDDEN_DIM_P2 = next_power_of_two(hidden_dim)
+
+    # For example, if you want to 2D-launch the kernel:
+    # - dimension 0 = number of tokens
+    # - dimension 1 = how many BLOCK_N segments needed for the vocab
+    _bgmv_sample_kernel_arbitrary[grid](hidden_state,
+                                        lm_heads_all,
+                                        lm_head_base,
+                                        logits,
+                                        sampling_indices_tensor,
+                                        HIDDEN_DIM=hidden_dim,
+                                        HIDDEN_DIM_P2=HIDDEN_DIM_P2,
+                                        VOCAB_SIZE=vocab_size,
+                                        **config)
+    return logits
+
+
+try:
+    direct_register_custom_op(op_name="bgmv_sample",
+                              op_func=_bgmv_sample,
+                              mutates_args=[],
+                              fake_impl=None)
+    bgmv_sample = torch.ops.aphrodite.bgmv_sample
+
+except AttributeError:
+    bgmv_sample = _bgmv_sample

--- a/aphrodite/lora/peft_helper.py
+++ b/aphrodite/lora/peft_helper.py
@@ -43,9 +43,6 @@ class PEFTHelper:
         error_msg = []
         warning_msg = []
 
-        if self.modules_to_save:
-            warning_msg.append(
-                "Aphrodite only supports modules_to_save being None.")
         if self.use_dora:
             error_msg.append("Aphrodite does not yet support DoRA.")
         return error_msg, warning_msg

--- a/aphrodite/lora/punica_wrapper/punica_base.py
+++ b/aphrodite/lora/punica_wrapper/punica_base.py
@@ -439,7 +439,7 @@ class PunicaWrapperBase(PunicaWrapperABC):
                         **kwargs) -> Optional[torch.Tensor]:
         """
         Applies lora  specifically for LogitsProcessorWithLoRA.
-        
+
         Semantics:
             buffer = (x @ lora_a_stacked) * scale
             y += buffer @ lora_b_stacked
@@ -452,5 +452,45 @@ class PunicaWrapperBase(PunicaWrapperABC):
             scale (float): Scaling factor.
             buffer (Optional[torch.Tensor]):Default to None.
         """
+        # TODO: implement it based on torch ops
+        raise NotImplementedError
+
+    def bgmv_sample(self, hidden_states: torch.Tensor,
+                    lm_heads_all: torch.Tensor, lm_head_base: torch.Tensor):
+        """
+        hidden_states - [num_tokens, hidden_dim]
+        lm_heads_all - [num_loras, vocab_size, hidden_dim]
+        the same as:
+        vocab_size=self.lm_head_tensors.shape[-2]
+        hidden_dim=hidden_states.size(0)
+
+        logits = torch.zeros((hidden_dim, vocab_size),
+                                 dtype=torch.float32,
+                                 device=hidden_states.device)
+
+        for i in range(len(hidden_states)):
+            if indices[i]==-1:
+                logits[i]=lm_head_base @ hidden_states[i]
+            else:
+                logits[i]=self.lm_head_tensors[indices[i]] @ hidden_states[i]
+        """
+
+        # TODO: implement it based on torch ops
+        raise NotImplementedError
+
+    def bgmv_embedding(self, tokens: torch.LongTensor,
+                       embed_tokens_all: torch.Tensor,
+                       embed_tokens_base: torch.Tensor) -> torch.Tensor:
+        """
+        embed_tokens_all - [num_loras, vocab_size, hidden_dim]
+            modules_to_save embeddings
+        embed_tokens_base - [vocab_size, hidden_dim] - base layer
+            embeddings will be applied to tokens with index=-1
+        tokens - [num_tokens]
+        returns:
+        embeddings: [num_tokens, hidden_dim]
+        
+        """
+
         # TODO: implement it based on torch ops
         raise NotImplementedError

--- a/aphrodite/lora/punica_wrapper/punica_gpu.py
+++ b/aphrodite/lora/punica_wrapper/punica_gpu.py
@@ -15,6 +15,8 @@ from aphrodite.triton_utils import HAS_TRITON
 
 if HAS_TRITON:
     from aphrodite.lora.ops.triton_ops import (
+        bgmv_embed,
+        bgmv_sample,
         LoRAKernelMeta,
         lora_expand,
         lora_shrink,
@@ -246,7 +248,7 @@ class PunicaWrapperGPU(PunicaWrapperBase):
                         **kwargs) -> None:
         """
         Applies lora  specifically for LogitsProcessorWithLoRA.
-        
+
         Semantics:
             buffer = (x @ lora_a_stacked) * scale
             y += buffer @ lora_b_stacked
@@ -278,3 +280,49 @@ class PunicaWrapperGPU(PunicaWrapperBase):
                     *self.prompt_mapping_meta.meta_args(buffer.size(0)),
                     add_inputs=True)
         y = y.view_as(y_org)
+
+    def bgmv_sample(self, hidden_states: torch.Tensor,
+                    lm_heads_all: torch.Tensor, lm_head_base: torch.Tensor):
+        """
+        hidden_states - [num_tokens, hidden_dim]
+        lm_heads_all - [num_loras, vocab_size, hidden_dim]
+        the same as:
+        vocab_size=self.lm_head_tensors.shape[-2]
+        hidden_dim=hidden_states.size(0)
+
+        logits = torch.zeros((hidden_dim, vocab_size),
+                                 dtype=torch.float32,
+                                 device=hidden_states.device)
+
+        for i in range(len(hidden_states)):
+            if indices[i]==-1:
+                logits[i]=lm_head_base @ hidden_states[i]
+            else:
+                logits[i]=self.lm_head_tensors[indices[i]] @ hidden_states[i]
+        """
+
+        indices = self.sampler_indices
+
+        logits = bgmv_sample(hidden_states, lm_heads_all, lm_head_base,
+                             indices)
+        return logits
+
+    def bgmv_embedding(self, tokens: torch.LongTensor,
+                       embed_tokens_all: torch.Tensor,
+                       embed_tokens_base: torch.Tensor) -> torch.Tensor:
+        """
+        embed_tokens_all - [num_loras, vocab_size, hidden_dim]
+            modules_to_save embeddings
+        embed_tokens_base - [vocab_size, hidden_dim] - base layer
+            embeddings will be applied to tokens with index=-1
+        tokens - [num_tokens]
+        returns:
+        embeddings: [num_tokens, hidden_dim]
+        """
+
+        embeddings = bgmv_embed(tokens,
+                                embed_tokens_all,
+                                embed_tokens_base,
+                                token_indices=self.token_lora_indices.long())
+
+        return embeddings

--- a/aphrodite/lora/worker_manager.py
+++ b/aphrodite/lora/worker_manager.py
@@ -80,6 +80,9 @@ class WorkerLoRAManager(AbstractWorkerManager):
 
     def _load_adapter(self, lora_request: LoRARequest) -> LoRAModel:
         try:
+            # Get the model first to avoid variable scope issues
+            model = self._adapter_manager.model
+
             supported_lora_modules = (
                 self._adapter_manager.supported_lora_modules)
             packed_modules_mapping = (
@@ -107,7 +110,6 @@ class WorkerLoRAManager(AbstractWorkerManager):
             # For some models like Qwen2VL, we need to use
             # hf_to_aphrodite_mapper
             # to ensure correct loading of lora weights.
-            model = self._adapter_manager.model
             hf_to_aphrodite_mapper = getattr(model, "hf_to_aphrodite_mapper",
                                              None)
 

--- a/aphrodite/lora/worker_manager.py
+++ b/aphrodite/lora/worker_manager.py
@@ -93,6 +93,7 @@ class WorkerLoRAManager(AbstractWorkerManager):
                     expected_lora_modules.append(module)
 
             expected_lora_modules = list(set(expected_lora_modules))
+            expected_modules_to_save: list[str] = model.modules_to_save
             lora_path = get_adapter_absolute_path(lora_request.lora_path)
 
             peft_helper = PEFTHelper.from_local_dir(
@@ -113,9 +114,12 @@ class WorkerLoRAManager(AbstractWorkerManager):
             lora = self._lora_model_cls.from_local_checkpoint(
                 lora_path,
                 expected_lora_modules,
+                expected_modules_to_save,
                 peft_helper=peft_helper,
                 lora_model_id=lora_request.lora_int_id,
                 device="cpu",
+                enable_lora_modules_to_save=self._adapter_manager.lora_config.
+                enable_lora_modules_to_save,
                 dtype=self.lora_config.lora_dtype,
                 target_embedding_padding=self.vocab_size +
                 self.lora_config.lora_extra_vocab_size,

--- a/aphrodite/modeling/layers/logits_processor.py
+++ b/aphrodite/modeling/layers/logits_processor.py
@@ -114,7 +114,7 @@ class LogitsProcessor(nn.Module):
 
         # Remove paddings in vocab (if any).
         if logits is not None:
-            logits = logits[..., :self.org_vocab_size]
+            logits = logits[..., :lm_head.org_vocab_size]
         return logits
 
     def extra_repr(self) -> str:

--- a/aphrodite/modeling/models/interfaces.py
+++ b/aphrodite/modeling/models/interfaces.py
@@ -227,6 +227,7 @@ class SupportsLoRA(Protocol):
     embedding_modules: ClassVar[dict[str, str]] = {}
     embedding_padding_modules: ClassVar[list[str]] = []
     packed_modules_mapping: ClassVar[dict[str, list[str]]] = {}
+    modules_to_save: ClassVar[list[str]] = ["lm_head", "embed_tokens"]
 
 
 # We can't use runtime_checkable with ClassVar for issubclass checks

--- a/aphrodite/modeling/models/llama.py
+++ b/aphrodite/modeling/models/llama.py
@@ -467,6 +467,10 @@ class LlamaForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
         "gate_up_proj": ["gate_proj", "up_proj"]
     }
 
+    supported_lora_modules = [
+        "qkv_proj", "o_proj", "gate_up_proj", "down_proj"
+    ] + SupportsLoRA.modules_to_save
+
     # LoRA specific attributes
     embedding_modules = {
         "embed_tokens": "input_embeddings",


### PR DESCRIPTION
Currently llama-only. Adding support for other arches should be relatively simple. To use:

```
--enable-lora-modules-to-save --enforce-eager
```

Technically works with graph capture and torch compile, but it's unstable. Needs investigating.