### PR TITLE
[Kernel] feat: add NVFP4 blockwise MoE kernels for sm_120

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,7 +263,8 @@ set(APHRODITE_EXT_SRC
   SET(CUTLASS_ENABLE_HEADERS_ONLY ON CACHE BOOL "Enable only the header library")
 
   # Set CUTLASS_REVISION. Used for FetchContent. Also fixes some bogus messages when building.
-  set(CUTLASS_REVISION "v4.0.0" CACHE STRING "CUTLASS revision to use")
+  # Updated to v4.2.0 (Sept 15, 2025) for improved SM120 support
+  set(CUTLASS_REVISION "v4.2.0" CACHE STRING "CUTLASS revision to use")
 
   # Use the specified CUTLASS source directory for compilation if APHRODITE_CUTLASS_SRC_DIR is provided
   if (DEFINED ENV{APHRODITE_CUTLASS_SRC_DIR})
@@ -553,7 +554,9 @@ set(APHRODITE_EXT_SRC
     set(SRCS
       "kernels/quantization/fp4/nvfp4_quant_kernels.cu"
       "kernels/quantization/fp4/activation_nvfp4_quant_fusion_kernels.cu"
-      "kernels/quantization/fp4/nvfp4_scaled_mm_sm120_kernels.cu")
+      "kernels/quantization/fp4/nvfp4_scaled_mm_sm120_kernels.cu"
+      "kernels/quantization/fp4/nvfp4_experts_quant.cu"
+      "kernels/quantization/fp4/nvfp4_blockwise_moe_sm120_kernels.cu")
     set_gencode_flags_for_srcs(
       SRCS "${SRCS}"
       CUDA_ARCHS "${FP4_ARCHS}")
@@ -634,7 +637,7 @@ set(APHRODITE_EXT_SRC
     endif()
   endif()
 
-  cuda_archs_loose_intersection(SCALED_MM_ARCHS "10.0a" "${CUDA_ARCHS}")
+  cuda_archs_loose_intersection(SCALED_MM_ARCHS "10.0a;12.0;12.0a" "${CUDA_ARCHS}")
   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.8 AND SCALED_MM_ARCHS)
     set(SRCS "kernels/quantization/cutlass_w8a8/moe/grouped_mm_c3x_sm100.cu")
     set_gencode_flags_for_srcs(
@@ -655,7 +658,7 @@ set(APHRODITE_EXT_SRC
   endif()
 
   # moe_data.cu is used by all CUTLASS MoE kernels.
-  cuda_archs_loose_intersection(CUTLASS_MOE_DATA_ARCHS "9.0a;10.0a" "${CUDA_ARCHS}")
+  cuda_archs_loose_intersection(CUTLASS_MOE_DATA_ARCHS "9.0a;10.0a;12.0;12.0a" "${CUDA_ARCHS}")
   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER_EQUAL 12.3 AND CUTLASS_MOE_DATA_ARCHS)
     set(SRCS "kernels/quantization/cutlass_w8a8/moe/moe_data.cu")
     set_gencode_flags_for_srcs(

--- a/aphrodite/_custom_ops.py
+++ b/aphrodite/_custom_ops.py
@@ -1066,6 +1066,20 @@ def cutlass_fp4_moe_mm(out_tensors: torch.Tensor, a_tensors: torch.Tensor,
     - problem_sizes: MxNxK sizes of each expert's multiplication in two grouped
                      MMs used in the fused MoE operation.
     """
+    # Detect SM120 architecture (RTX 5090/Blackwell GeForce)
+    device = a_tensors.device if a_tensors.is_cuda else torch.cuda.current_device()
+    major, minor = torch.cuda.get_device_capability(device)
+
+    # Use SM120 kernel for compute capability 12.0 and above
+    if major == 12 and minor == 0:
+        # Check if SM120 kernel is available
+        if hasattr(torch.ops._C, 'cutlass_fp4_group_mm_sm120'):
+            return torch.ops._C.cutlass_fp4_group_mm_sm120(
+                out_tensors, a_tensors, b_tensors,
+                a_scales, b_scales, alphas,
+                problem_sizes, expert_offsets, sf_offsets)
+
+    # Fall back to standard kernel
     return torch.ops._C.cutlass_fp4_group_mm(out_tensors, a_tensors, b_tensors,
                                              a_scales, b_scales, alphas,
                                              problem_sizes, expert_offsets,

--- a/kernels/ops.h
+++ b/kernels/ops.h
@@ -310,6 +310,12 @@ void cutlass_fp4_group_mm(
     const torch::Tensor& alphas, const torch::Tensor& problem_sizes,
     const torch::Tensor& expert_offsets, const torch::Tensor& sf_offsets);
 
+void cutlass_fp4_group_mm_sm120(
+    torch::Tensor& output, const torch::Tensor& a, const torch::Tensor& b,
+    const torch::Tensor& a_blockscale, const torch::Tensor& b_blockscales,
+    const torch::Tensor& alphas, const torch::Tensor& problem_sizes,
+    const torch::Tensor& expert_offsets, const torch::Tensor& sf_offsets);
+
 void get_cutlass_moe_mm_data(
     const torch::Tensor& topk_ids, torch::Tensor& expert_offsets,
     torch::Tensor& problem_sizes1, torch::Tensor& problem_sizes2,

--- a/kernels/quantization/fp4/nvfp4_blockwise_moe_kernel.cu
+++ b/kernels/quantization/fp4/nvfp4_blockwise_moe_kernel.cu
@@ -27,6 +27,7 @@
 #include "cutlass/util/reference/host/gett.hpp"
 #include "cutlass/util/reference/host/tensor_norm.h"
 #include "cutlass/util/reference/host/tensor_compare.h"
+#include "cutlass_extensions/common.hpp"
 #include <cassert>
 
 using namespace cute;
@@ -351,11 +352,29 @@ constexpr auto SF_DTYPE = at::ScalarType::Float8_e4m3fn;
   CHECK_CONTIGUOUS(x, m);     \
   CHECK_TYPE(x, st, m)
 
+#if defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120
+void cutlass_fp4_group_mm_sm120(
+    torch::Tensor& output, const torch::Tensor& a, const torch::Tensor& b,
+    const torch::Tensor& a_blockscale, const torch::Tensor& b_blockscales,
+    const torch::Tensor& alphas, const torch::Tensor& problem_sizes,
+    const torch::Tensor& expert_offsets, const torch::Tensor& sf_offsets);
+#endif
+
 void cutlass_fp4_group_mm(
     torch::Tensor& output, const torch::Tensor& a, const torch::Tensor& b,
     const torch::Tensor& a_blockscale, const torch::Tensor& b_blockscales,
     const torch::Tensor& alphas, const torch::Tensor& problem_sizes,
     const torch::Tensor& expert_offsets, const torch::Tensor& sf_offsets) {
+#if defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120
+  {
+    int32_t version_num = get_sm_version_num();
+    if (version_num >= 120) {
+      return cutlass_fp4_group_mm_sm120(output, a, b, a_blockscale,
+                                        b_blockscales, alphas, problem_sizes,
+                                        expert_offsets, sf_offsets);
+    }
+  }
+#endif
 #if defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100
   // Input validation
   CHECK_INPUT(a, FLOAT4_E2M1X2, "a");
@@ -395,10 +414,18 @@ void cutlass_fp4_group_mm(
         expert_offsets, sf_offsets, M, N, K);
   }
 #else
+#if defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120
+  {
+    int32_t version_num = get_sm_version_num();
+    if (version_num >= 120) {
+      return cutlass_fp4_group_mm_sm120(output, a, b, a_blockscale,
+                                        b_blockscales, alphas, problem_sizes,
+                                        expert_offsets, sf_offsets);
+    }
+  }
+#endif
   TORCH_CHECK_NOT_IMPLEMENTED(
       false,
-      "No compiled cutlass_fp4_group_mm kernel, Aphrodite must "
-      "be compiled with ENABLE_NVFP4_SM100 for SM100+ and CUDA "
-      "12.8 or above.");
+      "No compiled cutlass_fp4_group_mm kernel for this architecture.");
 #endif
 }

--- a/kernels/quantization/fp4/nvfp4_blockwise_moe_sm120_kernels.cu
+++ b/kernels/quantization/fp4/nvfp4_blockwise_moe_sm120_kernels.cu
@@ -1,0 +1,177 @@
+/*
+ * Minimal NVFP4 MoE Kernel for SM120 - Reference Implementation
+ */
+
+#include <torch/all.h>
+#include <ATen/cuda/CUDAContext.h>
+
+// NVFP4 E2M1 dequantization lookup table
+__device__ __forceinline__ float dequantize_nvfp4_e2m1(uint8_t fp4_val) {
+    static const float e2m1_table[16] = {
+        0.0f,   0.5f,   1.0f,   1.5f,
+        2.0f,   3.0f,   4.0f,   6.0f,
+        -0.0f,  -0.5f,  -1.0f,  -1.5f,
+        -2.0f,  -3.0f,  -4.0f,  -6.0f
+    };
+    return e2m1_table[fp4_val & 0xF];
+}
+
+// E4M3 scale factor dequantization
+__device__ __forceinline__ float dequantize_e4m3_scale(uint8_t e4m3_val) {
+    if (e4m3_val == 0) return 1.0f;
+
+    uint32_t sign = (e4m3_val >> 7) & 0x1;
+    uint32_t exp = (e4m3_val >> 3) & 0xF;
+    uint32_t mantissa = e4m3_val & 0x7;
+
+    if (exp == 0xF) return sign ? -448.0f : 448.0f;
+
+    float value = (exp == 0)
+        ? ldexpf(mantissa / 8.0f, -6)
+        : ldexpf(1.0f + mantissa / 8.0f, exp - 7);
+
+    return sign ? -value : value;
+}
+
+// NVFP4 MoE kernel
+template<typename OutType>
+__global__ void nvfp4_moe_kernel(
+    const uint8_t* __restrict__ a,
+    const uint8_t* __restrict__ b,
+    OutType* __restrict__ output,
+    const uint8_t* __restrict__ a_scales,
+    const uint8_t* __restrict__ b_scales,
+    const float* __restrict__ alphas,
+    const int32_t* __restrict__ problem_sizes,
+    const int32_t* __restrict__ expert_offsets,
+    const int32_t* __restrict__ sf_offsets,
+    int M, int N, int K, int num_experts) {
+
+    int tid_x = blockIdx.x * blockDim.x + threadIdx.x;
+    int tid_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (tid_y >= M || tid_x >= N) return;
+
+    // Find expert
+    int expert_id = -1;
+    for (int e = 0; e < num_experts; e++) {
+        int start = expert_offsets[e];
+        int end = (e == num_experts - 1) ? M : expert_offsets[e + 1];
+        if (tid_y >= start && tid_y < end) {
+            expert_id = e;
+            break;
+        }
+    }
+
+    if (expert_id < 0) return;
+
+    // Compute dot product in 16-element blocks
+    float sum = 0.0f;
+    int k_packed = K / 2;
+    int k_blocks = K / 16;
+
+    for (int block_idx = 0; block_idx < k_blocks; block_idx++) {
+        // Get scales (simplified indexing - complex swizzling logic preserved for correctness)
+        float a_scale = 1.0f, b_scale = 1.0f;
+
+        if (a_scales) {
+            int local_row = tid_y - expert_offsets[expert_id];
+            int global_row = sf_offsets[expert_id] + local_row;
+            int k_tiles = (K + 63) / 64;
+            int m_tile = global_row / 128;
+            int row128 = global_row % 128;
+            long long idx = (((((long long)m_tile * k_tiles + block_idx/4) * 32 + row128%32) * 4 + row128/32) * 4 + block_idx%4);
+            a_scale = dequantize_e4m3_scale(a_scales[idx]);
+        }
+
+        if (b_scales) {
+            int k_tiles = (K + 63) / 64;
+            int n_tiles = (N + 127) / 128;
+            long long base = (long long)expert_id * k_tiles * n_tiles * 512;
+            int m_tile = tid_x / 128;
+            int row128 = tid_x % 128;
+            long long idx = base + (((((long long)m_tile * k_tiles + block_idx/4) * 32 + row128%32) * 4 + row128/32) * 4 + block_idx%4);
+            b_scale = dequantize_e4m3_scale(b_scales[idx]);
+        }
+
+        // Process block
+        float block_sum = 0.0f;
+        for (int i = 0; i < 8; i++) {
+            int k = block_idx * 8 + i;
+            if (k >= k_packed) break;
+
+            uint8_t a_packed = a[tid_y * k_packed + k];
+            uint8_t b_packed = b[((long long)expert_id * N + tid_x) * k_packed + k];
+
+            float a0 = dequantize_nvfp4_e2m1(a_packed & 0x0F);
+            float a1 = dequantize_nvfp4_e2m1(a_packed >> 4);
+            float b0 = dequantize_nvfp4_e2m1(b_packed & 0x0F);
+            float b1 = dequantize_nvfp4_e2m1(b_packed >> 4);
+
+            block_sum += a0 * b0 + a1 * b1;
+        }
+
+        sum += block_sum * a_scale * b_scale;
+    }
+
+    if (alphas) sum *= alphas[expert_id];
+    output[tid_y * N + tid_x] = static_cast<OutType>(sum);
+}
+
+// Main entry point
+void cutlass_fp4_group_mm_sm120(
+    torch::Tensor& output,
+    const torch::Tensor& a,
+    const torch::Tensor& b,
+    const torch::Tensor& a_blockscale,
+    const torch::Tensor& b_blockscales,
+    const torch::Tensor& alphas,
+    const torch::Tensor& problem_sizes,
+    const torch::Tensor& expert_offsets,
+    const torch::Tensor& sf_offsets) {
+
+    // Basic validation
+    TORCH_CHECK(a.is_cuda() && a.is_contiguous() && a.scalar_type() == at::ScalarType::Byte);
+    TORCH_CHECK(b.is_cuda() && b.is_contiguous() && b.scalar_type() == at::ScalarType::Byte);
+    TORCH_CHECK(output.is_cuda() && output.is_contiguous());
+
+    // Check SM version
+    int32_t major, minor;
+    cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, 0);
+    cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, 0);
+    TORCH_CHECK(major * 10 + minor >= 120, "Requires SM120+");
+
+    // Get dimensions
+    int M = a.size(0);
+    int N = b.size(1);
+    int K = 2 * b.size(2);  // Unpacked K
+    int num_experts = expert_offsets.size(0);
+
+    // Launch kernel
+    dim3 block(16, 16);
+    dim3 grid((N + 15) / 16, (M + 15) / 16);
+    auto stream = at::cuda::getCurrentCUDAStream(a.device().index());
+
+    // Helper macro to avoid repetition
+#define LAUNCH_KERNEL(TYPE) \
+    nvfp4_moe_kernel<TYPE><<<grid, block, 0, stream>>>( \
+        reinterpret_cast<const uint8_t*>(a.data_ptr()), \
+        reinterpret_cast<const uint8_t*>(b.data_ptr()), \
+        reinterpret_cast<TYPE*>(output.data_ptr()), \
+        reinterpret_cast<const uint8_t*>(a_blockscale.data_ptr()), \
+        reinterpret_cast<const uint8_t*>(b_blockscales.data_ptr()), \
+        reinterpret_cast<const float*>(alphas.data_ptr()), \
+        reinterpret_cast<const int32_t*>(problem_sizes.data_ptr()), \
+        reinterpret_cast<const int32_t*>(expert_offsets.data_ptr()), \
+        reinterpret_cast<const int32_t*>(sf_offsets.data_ptr()), \
+        M, N, K, num_experts)
+
+    if (output.scalar_type() == torch::kBFloat16) {
+        LAUNCH_KERNEL(at::BFloat16);
+    } else if (output.scalar_type() == torch::kHalf) {
+        LAUNCH_KERNEL(at::Half);
+    } else {
+        LAUNCH_KERNEL(float);
+    }
+#undef LAUNCH_KERNEL
+}

--- a/kernels/quantization/fp4/nvfp4_quant_entry.cu
+++ b/kernels/quantization/fp4/nvfp4_quant_entry.cu
@@ -24,7 +24,8 @@ void scaled_fp4_quant_sm1xxa(torch::Tensor const& output,
                              torch::Tensor const& input_sf);
 #endif
 
-#if defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100
+#if (defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100) || \
+    (defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120)
 void scaled_fp4_experts_quant_sm100a(
     torch::Tensor& output, torch::Tensor& output_scale,
     torch::Tensor const& input, torch::Tensor const& input_global_scale,
@@ -46,7 +47,8 @@ void scaled_fp4_experts_quant(
     torch::Tensor const& input, torch::Tensor const& input_global_scale,
     torch::Tensor const& input_offset_by_experts,
     torch::Tensor const& output_scale_offset_by_experts) {
-#if defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100
+#if (defined ENABLE_NVFP4_SM100 && ENABLE_NVFP4_SM100) || \
+    (defined ENABLE_NVFP4_SM120 && ENABLE_NVFP4_SM120)
   return scaled_fp4_experts_quant_sm100a(
       output, output_scale, input, input_global_scale, input_offset_by_experts,
       output_scale_offset_by_experts);

--- a/kernels/torch_bindings.cpp
+++ b/kernels/torch_bindings.cpp
@@ -467,6 +467,15 @@ ops.def("cutlass_encode_and_reorder_int4b(Tensor B) -> Tensor");
       {stride_tag});
   ops.impl("cutlass_fp4_group_mm", torch::kCUDA, &cutlass_fp4_group_mm);
 
+  // cutlass nvfp4 block scaled group GEMM for SM120
+  // Always register for now to ensure it's available
+  ops.def(
+      "cutlass_fp4_group_mm_sm120(Tensor! out, Tensor a, Tensor b,"
+      " Tensor a_blockscale, Tensor b_blockscales, Tensor alphas,"
+      " Tensor problem_sizes, Tensor expert_offsets, Tensor sf_offsets) -> ()",
+      {stride_tag});
+  ops.impl("cutlass_fp4_group_mm_sm120", torch::kCUDA, &cutlass_fp4_group_mm_sm120);
+
   // CUTLASS w8a8 GEMM, supporting symmetric per-tensor or per-row/column
   // quantization, as well as bias
   ops.def(


### PR DESCRIPTION
Not fully optimized, as a lot of the sm_100 codepath is still used for this.

Tested with [alpindale/Ling-mini-2.0-NVFP4](https://huggingface.co/alpindale/Ling-mini-2.0-NVFP4), it gets about 91 tok/s decode (slower than the 140 tok/s with AWQ Marlin).