### PR TITLE
[core] feat: enable dynamic KV cache allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,9 @@ set(APHRODITE_EXT_SRC
   "kernels/quantization/activation_kernels.cu"
   "kernels/cuda_utils_kernels.cu"
   "kernels/all_reduce/custom_all_reduce.cu"
+  "kernels/vmm/page.cpp"
+  "kernels/vmm/ftensor.cpp"
+  "kernels/vmm/allocator.cpp"
   "kernels/torch_bindings.cpp")
 
   if(APHRODITE_GPU_LANG STREQUAL "CUDA")

--- a/aphrodite/_custom_ops.py
+++ b/aphrodite/_custom_ops.py
@@ -2823,3 +2823,34 @@ def fp_eXmY_linear_forward_cuda(exponent_bits: int, mantissa_bits: int,
                                 scales: torch.Tensor, splitK: int) -> torch.Tensor:
     return torch.ops._C.fp_eXmY_linear_forward_cuda(exponent_bits, mantissa_bits,
                                                     x, weights, scales, splitK)
+
+
+# VMM ops for elastic KV cache
+def init_kvcached(dev_str: str, page_size: int, contiguous_layout: bool) -> None:
+    """Initialize the kvcached VMM system."""
+    torch.ops._C.init_kvcached(dev_str, page_size, contiguous_layout)
+
+
+def shutdown_kvcached() -> None:
+    """Shutdown the kvcached VMM system."""
+    torch.ops._C.shutdown_kvcached()
+
+
+def create_kv_tensors(size: int, dtype_size: int, dev_str: str, num_layers: int) -> list[torch.Tensor]:
+    """Create KV cache tensors with virtual memory backing."""
+    return torch.ops._C.create_kv_tensors(size, dtype_size, dev_str, num_layers)
+
+
+def kv_tensors_created() -> bool:
+    """Check if KV tensors have been created."""
+    return torch.ops._C.kv_tensors_created()
+
+
+def map_to_kv_tensors(offsets: list[int]) -> None:
+    """Map physical memory pages to KV tensors at given offsets."""
+    torch.ops._C.map_to_kv_tensors(offsets)
+
+
+def unmap_from_kv_tensors(offsets: list[int]) -> None:
+    """Unmap physical memory pages from KV tensors at given offsets."""
+    torch.ops._C.unmap_from_kv_tensors(offsets)

--- a/aphrodite/envs.py
+++ b/aphrodite/envs.py
@@ -222,6 +222,7 @@ if TYPE_CHECKING:
     APHRODITE_REQUEST_LEVEL_METRICS: bool = True
     APHRODITE_USE_SAMPLING_KERNELS: bool = False
     APHRODITE_DISABLE_FLASH_ATTN_COMPILE: bool = False
+    APHRODITE_ENABLE_DYNAMIC_KV_CACHE: bool = False
 
 
 def get_default_cache_root():
@@ -1468,6 +1469,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to disable flash attention compilation
     "APHRODITE_DISABLE_FLASH_ATTN_COMPILE": lambda: bool(
         int(os.getenv("APHRODITE_DISABLE_FLASH_ATTN_COMPILE", "0"))
+    ),
+
+    # When enabled without prefix caching, allow aphrodite to dynamically
+    # allocate KV cache memory instead of pre-allocation.
+    "APHRODITE_ENABLE_DYNAMIC_KV_CACHE": lambda: bool(
+        int(os.getenv("APHRODITE_ENABLE_DYNAMIC_KV_CACHE", "0"))
     ),
 }
 

--- a/aphrodite/v1/core/block_pool.py
+++ b/aphrodite/v1/core/block_pool.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any
 
 from aphrodite.distributed.kv_events import (MEDIUM_GPU, AllBlocksCleared,
@@ -414,3 +414,109 @@ class BlockPool:
         events = self.kv_event_queue
         self.kv_event_queue = []
         return events
+
+
+class ElasticBlockPool(BlockPool):
+    """ElasticBlockPool that manages KVCacheBlocks.
+    It provides same interface as BlockPool, but it leverages kvcached for
+    elastic KV cachememory management.
+    """
+
+    def __init__(self,
+                 num_gpu_blocks: int,
+                 block_size: int,
+                 cell_size: int,
+                 num_layers: int,
+                 enable_caching: bool,
+                 enable_kv_cache_events: bool = False):
+        # NOTE: Do not call super().__init__() here because we just want to
+        # keep the same interface as BlockPool but not its implementation.
+        assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
+        assert not enable_caching, (
+            "Caching is not supported in ElasticBlockPool")
+        assert not enable_kv_cache_events, (
+            "KV cache events are not supported in ElasticBlockPool")
+
+        self.num_gpu_blocks = num_gpu_blocks
+        self.enable_kv_cache_events = enable_kv_cache_events
+        self.kv_event_queue: list[KVCacheEvent] = []
+
+        from aphrodite.v1.core.dynamic_kv.interfaces import (
+            get_kv_cache_manager)
+
+        self.kv_cache_manager = get_kv_cache_manager(num_gpu_blocks,
+                                                     block_size, cell_size,
+                                                     num_layers)
+
+        self.null_block = None  # type: ignore
+
+    def get_cached_block(
+            self, block_hash: BlockHash,
+            kv_cache_group_ids: list[int]) -> list[KVCacheBlock] | None:
+        return None
+
+    def cache_full_blocks(
+        self,
+        request: Request,
+        blocks: list[KVCacheBlock],
+        block_hashes: list[BlockHash],
+        num_cached_blocks: int,
+        num_full_blocks: int,
+        block_size: int,
+        kv_cache_group_id: int,
+        hash_fn: Callable,
+    ) -> None:
+        raise NotImplementedError(
+            "Caching is not supported in ElasticBlockPool")
+
+    def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
+        """Get new blocks from the free block pool.
+        Note that we do not check block cache in this function.
+        Args:
+            num_blocks: The number of blocks to allocate.
+        Returns:
+            A list of new block.
+        """
+        if num_blocks > self.get_num_free_blocks():
+            raise ValueError(
+                f"Cannot get {num_blocks} free blocks from the pool")
+
+        block_ids = self.kv_cache_manager.alloc(num_blocks)
+        assert block_ids is not None and len(block_ids) == num_blocks
+
+        return [KVCacheBlock(bid) for bid in block_ids]
+
+    def touch(self, blocks: tuple[list[KVCacheBlock], ...]) -> None:
+        raise NotImplementedError("Not supported in ElasticBlockPool")
+
+    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
+        """Free a list of blocks. The blocks should be ordered by their
+        eviction priority, where the first block will be evicted first.
+        Args:
+            ordered_blocks: A list of blocks to free ordered by their eviction
+                priority.
+        """
+        block_ids = [block.block_id for block in ordered_blocks]
+        if len(block_ids) > 0:
+            self.kv_cache_manager.free(block_ids)
+
+    def reset_prefix_cache(self) -> bool:
+        raise NotImplementedError("Not supported in ElasticBlockPool")
+
+    def get_num_free_blocks(self) -> int:
+        """Get the number of free blocks in the pool.
+        Returns:
+            The number of free blocks.
+        """
+        return self.kv_cache_manager.available_size()
+
+    def get_usage(self) -> float:
+        """Get the KV cache usage.
+        Returns:
+            The KV cache usage (between 0.0 and 1.0).
+        """
+        return 1.0 - (self.get_num_free_blocks() / self.num_gpu_blocks)
+
+    def take_events(self) -> list[KVCacheEvent]:
+        """ElasticBlockPool does not generate events; always return empty."""
+        return []

--- a/aphrodite/v1/core/dynamic_kv/LICENSE
+++ b/aphrodite/v1/core/dynamic_kv/LICENSE
@@ -1,0 +1,204 @@
+Based on https://github.com/ovg-project/kvcached/tree/c064163eab4a2b042e84ac68787138613e5c6ee5
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/aphrodite/v1/core/dynamic_kv/__init__.py
+++ b/aphrodite/v1/core/dynamic_kv/__init__.py
@@ -1,0 +1,64 @@
+from .cli_utils import (MemInfoStruct, RwLockedShm, delete_kv_cache_segment,
+                        get_ipc_name, get_ipc_path, get_kv_cache_limit,
+                        get_total_gpu_memory, init_kv_cache_limit,
+                        update_kv_cache_limit)
+from .interfaces import (alloc_kv_cache, get_kv_cache_manager, init_kvcached,
+                         shutdown_kvcached)
+from .kv_cache_manager import KVCacheManager
+from .locks import ConditionLike, LockLike, NoOpCondition, NoOpLock
+from .mem_info_tracker import MemInfoTracker
+from .page_allocator import Page, PageAllocator
+from .tp_ipc_util import (broadcast_kv_tensors_created,
+                          broadcast_map_to_kv_tensors,
+                          broadcast_unmap_from_kv_tensors,
+                          start_worker_listener_thread)
+from .utils import (CONTIGUOUS_LAYOUT, DEFAULT_IPC_NAME, GPU_UTILIZATION,
+                    MAX_RESERVED_PAGES, MIN_RESERVED_PAGES,
+                    PAGE_PREALLOC_ENABLED, PAGE_SIZE, SANITY_CHECK, SHM_DIR,
+                    align_to, align_up_to_page)
+
+try:
+    from . import vmm_ops
+except ImportError:
+    vmm_ops = None
+
+__all__ = [
+    "MemInfoStruct",
+    "RwLockedShm",
+    "delete_kv_cache_segment",
+    "get_ipc_name",
+    "get_ipc_path",
+    "get_kv_cache_limit",
+    "get_total_gpu_memory",
+    "init_kv_cache_limit",
+    "update_kv_cache_limit",
+    "alloc_kv_cache",
+    "get_kv_cache_manager",
+    "init_kvcached",
+    "shutdown_kvcached",
+    "KVCacheManager",
+    "ConditionLike",
+    "LockLike",
+    "NoOpCondition",
+    "NoOpLock",
+    "MemInfoTracker",
+    "Page",
+    "PageAllocator",
+    "broadcast_kv_tensors_created",
+    "broadcast_map_to_kv_tensors",
+    "broadcast_unmap_from_kv_tensors",
+    "start_worker_listener_thread",
+    "CONTIGUOUS_LAYOUT",
+    "DEFAULT_IPC_NAME",
+    "GPU_UTILIZATION",
+    "MAX_RESERVED_PAGES",
+    "MIN_RESERVED_PAGES",
+    "PAGE_PREALLOC_ENABLED",
+    "PAGE_SIZE",
+    "SANITY_CHECK",
+    "SHM_DIR",
+    "align_to",
+    "align_up_to_page",
+    "vmm_ops",
+]
+

--- a/aphrodite/v1/core/dynamic_kv/cli_utils.py
+++ b/aphrodite/v1/core/dynamic_kv/cli_utils.py
@@ -1,0 +1,174 @@
+import fcntl
+import mmap
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+import posix_ipc
+
+from .utils import SHM_DIR
+
+
+def get_ipc_path(ipc_name: str) -> str:
+    """Convert IPC name to full path in /dev/shm."""
+    if ipc_name.startswith('/'):
+        return ipc_name
+    return os.path.join(SHM_DIR, ipc_name)
+
+
+def get_ipc_name(ipc_path: str) -> str:
+    """Convert full path to IPC name for posix_ipc."""
+    return os.path.basename(ipc_path)
+
+
+@dataclass
+class MemInfoStruct:
+    total_size: int
+    used_size: int
+    prealloc_size: int
+
+    DTYPE = np.int64
+    N_FIELDS = 3
+    SHM_SIZE = np.dtype(DTYPE).itemsize * N_FIELDS
+
+    @classmethod
+    def _view(cls, buf: mmap.mmap) -> np.ndarray:
+        """Return a live NumPy view onto the shared buffer."""
+        return np.ndarray((cls.N_FIELDS, ), dtype=cls.DTYPE, buffer=buf)
+
+    @classmethod
+    def from_buffer(cls, buf: mmap.mmap) -> "MemInfoStruct":
+        arr = cls._view(buf)
+        return cls(int(arr[0]), int(arr[1]), int(arr[2]))
+
+    def write_to_buffer(self, buf: mmap.mmap) -> None:
+        arr = self._view(buf)
+        arr[:] = (self.total_size, self.used_size, self.prealloc_size)
+
+
+class RwLockedShm:
+    RLOCK = fcntl.LOCK_SH
+    WLOCK = fcntl.LOCK_EX
+
+    def __init__(self, file_path: str, size: int, lock_type: int):
+        self.file_path = get_ipc_path(file_path)
+        self.mode = "r+b"
+        self.size = size
+        self.lock_type = lock_type
+
+    def __enter__(self):
+        try:
+            self.file = open(self.file_path, self.mode)
+        except FileNotFoundError:
+            if self.lock_type != RwLockedShm.WLOCK:
+                raise
+            self.file = open(self.file_path, "w+b")
+            self.file.truncate(self.size)
+
+        stat_info = os.fstat(self.file.fileno())
+        if stat_info.st_size < self.size and self.lock_type == RwLockedShm.WLOCK:
+            self.file.truncate(self.size)
+
+        fcntl.flock(self.file, self.lock_type)
+        access = mmap.ACCESS_READ if self.lock_type == fcntl.LOCK_SH else mmap.ACCESS_WRITE
+        self.mm = mmap.mmap(self.file.fileno(), self.size, access=access)
+        return self.mm
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.mm.close()
+        fcntl.flock(self.file, fcntl.LOCK_UN)
+        self.file.close()
+
+
+def init_kv_cache_limit(ipc_name: str, kv_cache_limit: int):
+    """Set the kv cache limit for the current process."""
+    shm = posix_ipc.SharedMemory(get_ipc_name(ipc_name),
+                                 posix_ipc.O_CREAT,
+                                 size=MemInfoStruct.SHM_SIZE,
+                                 mode=0o666)
+    shm.close_fd()
+
+    with RwLockedShm(get_ipc_name(ipc_name), MemInfoStruct.SHM_SIZE,
+                     RwLockedShm.WLOCK) as mm:
+        mem_info = MemInfoStruct(kv_cache_limit, 0, 0)
+        mem_info.write_to_buffer(mm)
+        return mem_info
+
+
+def get_kv_cache_limit(ipc_name: str) -> Optional[MemInfoStruct]:
+    """Get the kv cache limit for the current process."""
+    try:
+        with RwLockedShm(get_ipc_name(ipc_name), MemInfoStruct.SHM_SIZE,
+                         RwLockedShm.RLOCK) as mm:
+            return MemInfoStruct.from_buffer(mm)
+    except FileNotFoundError:
+        return None
+
+
+def update_kv_cache_limit(ipc_name: str,
+                          kv_cache_limit: int) -> Optional[MemInfoStruct]:
+    """Update the kv cache limit for the current process."""
+    try:
+        with RwLockedShm(get_ipc_name(ipc_name), MemInfoStruct.SHM_SIZE,
+                         RwLockedShm.WLOCK) as mm:
+            mem_info = MemInfoStruct.from_buffer(mm)
+            delta = kv_cache_limit - mem_info.total_size
+            if delta < 0:
+                if mem_info.used_size > kv_cache_limit:
+                    print(
+                        f"No enough free space to decrease for the new kv_cache_limit for {ipc_name}"
+                    )
+            mem_info.total_size = kv_cache_limit
+            mem_info.write_to_buffer(mm)
+            human_limit = _format_size(kv_cache_limit)
+            print(
+                f"Updated kv cache limit for {ipc_name} to {human_limit} ({kv_cache_limit} bytes)"
+            )
+            return mem_info
+    except FileNotFoundError:
+        return None
+
+
+def delete_kv_cache_segment(ipc_name: str) -> bool:
+    """Remove the shared-memory segment and backing file for *ipc_name*."""
+    shm_name = get_ipc_name(ipc_name)
+
+    removed = False
+    try:
+        posix_ipc.unlink_shared_memory(shm_name)
+        removed = True
+    except posix_ipc.ExistentialError:
+        pass
+
+    try:
+        os.unlink(get_ipc_path(shm_name))
+        removed = True or removed
+    except FileNotFoundError:
+        pass
+
+    return removed
+
+
+def get_total_gpu_memory() -> int:
+    """Return total memory of CUDA device 0 or 0 if CUDA unavailable."""
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            return torch.cuda.get_device_properties(0).total_memory
+    except Exception:
+        pass
+    return 0
+
+
+def _format_size(num_bytes: int) -> str:
+    """Return human-readable size (B, KB, MB, GB, TB)."""
+    size: float = float(num_bytes)
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size < 1024 or unit == "TB":
+            return f"{size:.2f} {unit}"
+        size /= 1024
+
+    raise RuntimeError("_format_size fell through all units")
+

--- a/aphrodite/v1/core/dynamic_kv/interfaces.py
+++ b/aphrodite/v1/core/dynamic_kv/interfaces.py
@@ -1,0 +1,139 @@
+import math
+from typing import List, Optional, Tuple
+
+import torch
+
+from .kv_cache_manager import KVCacheManager
+from .tp_ipc_util import start_worker_listener_thread
+from .utils import CONTIGUOUS_LAYOUT, PAGE_SIZE
+
+try:
+    from . import vmm_ops
+    _vmm_ops_available = True
+except ImportError:
+    _vmm_ops_available = False
+
+from aphrodite.logger import init_logger
+
+logger = init_logger(__name__)
+
+_kvcached_initialized: bool = False
+_kvcached_device = None
+_async_sched = False
+_tp_size: int = 1
+_contiguous_layout: bool = CONTIGUOUS_LAYOUT
+
+
+def init_kvcached(
+    tp_rank: int = 0,
+    tp_size: int = 1,
+    is_worker: bool = False,
+    device: Optional[str] = None,
+    async_sched: bool = False,
+) -> None:
+    global _kvcached_initialized, _kvcached_device, _tp_size, _async_sched
+    if _kvcached_initialized:
+        return
+
+    if device is None:
+        device = f"cuda:{torch.cuda.current_device()}"
+
+    if _vmm_ops_available:
+        vmm_ops.init_kvcached(device, PAGE_SIZE, _contiguous_layout)
+    _kvcached_initialized = True
+    _kvcached_device = device
+    _tp_size = tp_size
+    _async_sched = async_sched
+
+    if tp_size > 1 and is_worker:
+        start_worker_listener_thread(tp_rank)
+
+
+def shutdown_kvcached() -> None:
+    global _kvcached_initialized, _kvcached_device, _async_sched
+    if not _kvcached_initialized:
+        return
+
+    if _vmm_ops_available:
+        vmm_ops.shutdown_kvcached()
+    _kvcached_initialized = False
+    _kvcached_device = None
+    _async_sched = False
+
+
+def alloc_kv_cache(
+    kvcache_shape: Tuple[int, ...],  # (2, num_blocks, block_size, head_num, head_dim)
+    block_size: int,
+    dtype: torch.dtype,
+    device: str,
+    num_layers: int,
+    attention_type: str = "MHA",  # GQA is also supported. TODO: support MLA
+    kv_layout: str = "NHD",  # NHD: (num_tokens, head_num, head_dim)
+) -> List[torch.Tensor]:
+    if not _kvcached_initialized:
+        raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
+
+    if attention_type not in ["MHA", "GQA"]:
+        raise ValueError(f"Attention type {attention_type} is not supported.")
+    num_k_or_v = 2
+    requested_num_blocks = kvcache_shape[1]
+
+    if kv_layout != "NHD":
+        raise ValueError(f"KV layout {kv_layout} is not supported.")
+
+    if len(kvcache_shape) <= 3 or kvcache_shape[0] != num_k_or_v or kvcache_shape[2] != block_size:
+        raise ValueError(f"Unsupported kv cache shape: {kvcache_shape}")
+
+    assert torch.cuda.is_available(), "CUDA is not available."
+
+    gpu_mem_bytes = torch.cuda.get_device_properties(device).total_memory
+    gpu_mem_bytes_per_layer_k_or_v = gpu_mem_bytes // num_layers // num_k_or_v
+    # round down to page size
+    gpu_mem_bytes_per_layer_k_or_v = (gpu_mem_bytes_per_layer_k_or_v // PAGE_SIZE) * PAGE_SIZE
+
+    block_mem_bytes = math.prod(kvcache_shape[2:]) * dtype.itemsize
+    num_blocks_per_layer = gpu_mem_bytes_per_layer_k_or_v // block_mem_bytes
+    if requested_num_blocks > num_blocks_per_layer:
+        logger.warning(
+            f"Requested {requested_num_blocks} blocks, but only {num_blocks_per_layer} blocks are available."
+        )
+
+    if _vmm_ops_available:
+        raw_kv_tensors = vmm_ops.create_kv_tensors(
+            gpu_mem_bytes_per_layer_k_or_v * num_k_or_v, dtype.itemsize, device, num_layers
+        )
+    else:
+        raise RuntimeError("VMM operations not available. Elastic KV cache requires building with VMM support.")
+
+    actual_kvcache_shape: List[int] = list(kvcache_shape)
+    actual_kvcache_shape[1] = num_blocks_per_layer
+    if not _contiguous_layout:
+        num_eles = math.prod(actual_kvcache_shape)
+        kv_tensors = [
+            t.view(dtype=dtype)[:num_eles].view(tuple(actual_kvcache_shape)) for t in raw_kv_tensors
+        ]
+    else:
+        contiguous_shape = (num_blocks_per_layer, num_layers, num_k_or_v, *actual_kvcache_shape[2:])
+        num_eles = math.prod(contiguous_shape)
+        contiguous_tensor = raw_kv_tensors[0].view(dtype=dtype)[:num_eles].view(contiguous_shape)
+        kv_tensors = [
+            contiguous_tensor[:, i, :, :, :].permute(1, 0, *range(2, len(actual_kvcache_shape)))
+            for i in range(num_layers)
+        ]
+    return kv_tensors
+
+
+def get_kv_cache_manager(
+    num_blocks: int, block_size: int, cell_size: int, num_layers: int
+) -> KVCacheManager:
+    if not _kvcached_initialized:
+        raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
+
+    return KVCacheManager(
+        num_blocks,
+        block_size,
+        cell_size,
+        num_layers,
+        _tp_size,
+        async_sched=_async_sched,
+    )

--- a/aphrodite/v1/core/dynamic_kv/kv_cache_manager.py
+++ b/aphrodite/v1/core/dynamic_kv/kv_cache_manager.py
@@ -1,0 +1,323 @@
+import functools
+import threading
+import time
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+from .locks import NoOpLock
+from .page_allocator import Page, PageAllocator
+from .tp_ipc_util import broadcast_kv_tensors_created
+from .utils import PAGE_SIZE, SANITY_CHECK
+
+try:
+    from aphrodite.v1.core.dynamic_kv import vmm_ops
+    _vmm_ops_available = True
+except ImportError:
+    _vmm_ops_available = False
+
+from aphrodite.logger import init_logger
+
+logger = init_logger(__name__)
+
+KV_TENSOR_WAIT_TIMEOUT: float = 10.0
+
+
+def synchronized(method):
+    """A helper decorator to synchronize access to a method."""
+
+    @functools.wraps(method)
+    def synchronized_method(self, *args, **kwargs):
+        with self._lock:
+            return method(self, *args, **kwargs)
+
+    return synchronized_method
+
+
+class KVCacheManager:
+
+    def __init__(
+        self,
+        num_blocks: int,
+        block_size: int,
+        cell_size: int,
+        num_layers: int,
+        tp_size: int = 1,
+        async_sched: bool = False,
+        reserve_null_block: bool = False,
+    ):
+        """
+        Args:
+            num_blocks: Number of blocks.
+            block_size: Size of each block in bytes.
+            cell_size: Size of each cell in bytes.
+            num_layers: Number of layers.
+            tp_size: Number of tensor parallel processes.
+            async_sched: Whether asynchronous scheduling is enabled.
+            reserve_null_block: Whether to reserve the first block as null block
+                for padding tokens. This is required by SGLang which assumes the
+                first block is always reserved as padded tokens.
+        """
+        self.num_blocks = num_blocks
+        self.block_mem_size = block_size * cell_size
+        self.num_layers = num_layers
+        self.reserve_null_block = reserve_null_block
+
+        self.page_size = PAGE_SIZE
+        self.mem_size = self.num_blocks * self.block_mem_size
+        self.tp_size = tp_size
+        self.page_allocator = PageAllocator(
+            self.num_layers,
+            self.mem_size,
+            self.page_size,
+            self.tp_size,
+            async_sched=async_sched,
+        )
+
+        self.num_avail_blocks = 0
+        self.avail_pages: Dict[int, Page] = {}
+        self.full_pages: Dict[int, Page] = {}
+
+        self.reserved_blocks: List[int] = []
+        self.null_block: Optional[list[int]] = None
+
+        self.in_shrink: bool = False
+        self.target_num_blocks: Optional[int] = None
+        self._lock = threading.RLock() if async_sched else NoOpLock()
+
+        self._post_init_done = threading.Event()
+        threading.Thread(target=self._post_init, daemon=True).start()
+
+    def _post_init(self):
+        if self.null_block is not None:
+            return
+
+        def _check_kv_tensors_created():
+            if not _vmm_ops_available:
+                return True
+            if self.tp_size > 1:
+                return broadcast_kv_tensors_created(self.tp_size)
+            else:
+                return vmm_ops.kv_tensors_created()
+
+        try:
+            total_wait = 0.0
+            while not _check_kv_tensors_created():
+                if total_wait >= KV_TENSOR_WAIT_TIMEOUT:
+                    raise TimeoutError("KV tensors not created after "
+                                       f"{KV_TENSOR_WAIT_TIMEOUT} seconds")
+
+                time.sleep(0.001)
+                total_wait += 0.001
+
+            if self.reserve_null_block:
+                self.null_block = self._alloc(1, _skip_wait=True)
+                if self.null_block != [0]:
+                    logger.error(
+                        f"Failed to reserve null block, got {self.null_block}")
+                    raise RuntimeError(
+                        "Failed to reserve null block at index 0")
+
+            self.page_allocator.start_prealloc_thread()
+        except Exception as e:
+            logger.error(
+                f"Error during KVCacheManager post-initialization: {e}")
+            raise
+        finally:
+            self._post_init_done.set()
+
+    def _wait_post_init(self):
+        if not self._post_init_done.is_set():
+            self._post_init_done.wait()
+
+    def alloc(self, need_size: int) -> Optional[List[int]]:
+        return self._alloc(need_size)
+
+    @synchronized
+    def _alloc(self,
+               need_size: int,
+               _skip_wait: bool = False) -> Optional[List[int]]:
+        if not _skip_wait:
+            self._wait_post_init()
+
+        new_mem_size = self.page_allocator.mem_info_tracker.check_and_get_resize_target(
+            self.mem_size, self.num_layers)
+        if new_mem_size is not None:
+            self.resize(new_mem_size)
+
+        if self.available_size() < need_size:
+            logger.warning(f"available_size()={self.available_size()} < "
+                           f"need_size={need_size}")
+            return None
+
+        ret_index = []
+        page: Optional[Page] = None
+
+        remaining_need = need_size
+
+        if self.reserved_blocks:
+            num_from_reserved = min(len(self.reserved_blocks), remaining_need)
+            ret_index = self.reserved_blocks[:num_from_reserved]
+            self.reserved_blocks = self.reserved_blocks[num_from_reserved:]
+            remaining_need -= num_from_reserved
+
+        while remaining_need > 0:
+            if not self.avail_pages:
+                page = self.page_allocator.alloc_page()
+                page.init(self.block_mem_size)
+                self.num_avail_blocks += page.num_free_blocks()
+            else:
+                _, page = self.avail_pages.popitem()
+            num_from_page = min(page.num_free_blocks(), remaining_need)
+            alloced_index = page.alloc(num_from_page)
+            ret_index.extend(alloced_index)
+            if page.full():
+                self.full_pages[page.page_id] = page
+            else:
+                self.avail_pages[page.page_id] = page
+
+            self.num_avail_blocks -= num_from_page
+            remaining_need -= num_from_page
+
+        return ret_index
+
+    @synchronized
+    def free(self, indices: List[int]):
+        self._wait_post_init()
+
+        if len(indices) == 0:
+            return
+
+        if SANITY_CHECK:
+            for idx in indices:
+                if idx in self.reserved_blocks:
+                    raise ValueError(f"Freed index {idx} is in "
+                                     " reserved_blocks, which is not allowed.")
+
+        idx_dict = defaultdict(list)
+        for idx in indices:
+            page_id = self.page_allocator.get_page_id(idx, self.block_mem_size)
+            idx_dict[page_id].append(idx)
+
+        pages_to_free: List[int] = []
+        for page_id, idxs in idx_dict.items():
+            page = None
+            if page_id in self.full_pages:
+                page = self.full_pages.pop(page_id)
+            elif page_id in self.avail_pages:
+                page = self.avail_pages.pop(page_id)
+            else:
+                if SANITY_CHECK:
+                    raise ValueError(
+                        f"Page {page_id} not found in avail_pages or full_pages. "
+                        f"This indicates a serious state inconsistency.")
+                else:
+                    logger.error(
+                        f"Page {page_id} not found in avail_pages or full_pages. "
+                        f"Skipping to avoid crash, but this indicates a serious bug."
+                    )
+                    continue
+
+            self.num_avail_blocks += len(idxs)
+            page.free_batch(idxs)
+
+            if page.empty():
+                pages_to_free.append(page.page_id)
+                self.num_avail_blocks -= page.num_free_blocks()
+            else:
+                self.avail_pages[page_id] = page
+
+        if pages_to_free:
+            self.page_allocator.free_pages(pages_to_free)
+
+        if self.in_shrink:
+            assert self.target_num_blocks is not None
+            if self._get_num_alloced_blocks() <= self.target_num_blocks:
+                self.page_allocator.resize(self.target_num_blocks *
+                                           self.block_mem_size)
+                self.in_shrink = False
+                self.target_num_blocks = None
+
+    @synchronized
+    def try_to_reserve(self, need_size: int) -> bool:
+        self._wait_post_init()
+        if self.available_size() < need_size:
+            return False
+        reserved = self.alloc(need_size)
+        if reserved is None:
+            logger.warning("Failed to reserve blocks.")
+            return False
+        self.reserved_blocks.extend(reserved)
+        return True
+
+    @synchronized
+    def free_reserved(self):
+        if self.reserved_blocks:
+            self.free(self.reserved_blocks)
+            self.reserved_blocks = []
+
+    @synchronized
+    def resize(self, new_mem_size: int):
+        """Reset the limit of the K or V tensor in one layer."""
+        self._wait_post_init()
+        assert new_mem_size > 0, "new_mem_size must be positive"
+        if self.page_allocator.resize(new_mem_size):
+            if self.in_shrink:
+                self.in_shrink = False
+                self.target_num_blocks = None
+            return True
+        assert (len(self.reserved_blocks) == 0
+                ), "Reserved blocks must be freed before resizing."
+        self.in_shrink = True
+        self.target_num_blocks = new_mem_size // self.block_mem_size
+        self.free_reserved()
+        return False
+
+    @synchronized
+    def trim(self):
+        self._wait_post_init()
+        self.page_allocator.trim()
+
+    @synchronized
+    def available_size(self) -> int:
+        avail_blocks = self.num_avail_blocks + len(self.reserved_blocks)
+        if self.in_shrink:
+            blocks_from_free_pages = 0
+        else:
+            virtual_free_pages = self.page_allocator.get_num_free_pages()
+            physical_free_pages = self.page_allocator.get_avail_physical_pages(
+            ) + self.page_allocator.get_num_reserved_pages()
+            free_pages = min(virtual_free_pages, physical_free_pages)
+            blocks_from_free_pages = free_pages * Page.get_num_blocks(
+                self.page_size, self.block_mem_size)
+        return avail_blocks + blocks_from_free_pages
+
+    @synchronized
+    def get_mapped_memory_size(self, unit='bytes') -> float:
+        """Get memory usage in specified unit (bytes, kb, mb, gb)."""
+        memory_bytes = (self.page_allocator.get_num_inuse_pages() *
+                        self.num_layers * self.page_size * 2)
+
+        if unit == 'bytes':
+            return memory_bytes
+        elif unit == 'kb':
+            return memory_bytes / 1024
+        elif unit == 'mb':
+            return memory_bytes / (1024**2)
+        elif unit == 'gb':
+            return memory_bytes / (1024**3)
+        else:
+            raise ValueError(f"Unknown unit: {unit}")
+
+    def clear(self):
+        raise NotImplementedError("kvcached does not support clear() for now")
+
+    @synchronized
+    def _get_num_alloced_blocks(self) -> int:
+        blocks_from_full_pages = len(self.full_pages) * Page.get_num_blocks(
+            self.page_size, self.block_mem_size)
+        blocks_from_avail_pages = len(self.avail_pages) * Page.get_num_blocks(
+            self.page_size, self.block_mem_size) - self.num_avail_blocks
+        blocks_from_reserved_blocks = len(self.reserved_blocks)
+        return (blocks_from_full_pages + blocks_from_avail_pages +
+                blocks_from_reserved_blocks)
+

--- a/aphrodite/v1/core/dynamic_kv/locks.py
+++ b/aphrodite/v1/core/dynamic_kv/locks.py
@@ -1,0 +1,95 @@
+from typing import Any, Callable, Optional, Protocol
+
+
+class LockLike(Protocol):
+
+    def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
+        ...
+
+    def release(self) -> None:
+        ...
+
+    def __enter__(self) -> bool:
+        ...
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        ...
+
+
+class ConditionLike(Protocol):
+
+    def wait(self, timeout: Optional[float] = None) -> bool:
+        ...
+
+    def wait_for(self,
+                 predicate: Callable[[], bool],
+                 timeout: Optional[float] = None) -> bool:
+        ...
+
+    def notify(self, n: int = 1) -> None:
+        ...
+
+    def notify_all(self) -> None:
+        ...
+
+    def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
+        ...
+
+    def release(self) -> None:
+        ...
+
+    def __enter__(self) -> bool:
+        ...
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        ...
+
+
+class NoOpLock(LockLike):
+    """A no-op lock that implements the same interface as threading.RLock"""
+
+    def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
+        return True
+
+    def release(self) -> None:
+        pass
+
+    def __enter__(self) -> bool:
+        return True
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        pass
+
+
+class NoOpCondition(ConditionLike):
+    """A no-op condition that implements the same interface as threading.Condition"""
+
+    def __init__(self, lock: LockLike):
+        self.lock = lock
+
+    def wait(self, timeout: Optional[float] = None) -> bool:
+        return True
+
+    def wait_for(self,
+                 predicate: Callable[[], bool],
+                 timeout: Optional[float] = None) -> bool:
+        return predicate()
+
+    def notify(self, n: int = 1) -> None:
+        pass
+
+    def notify_all(self) -> None:
+        pass
+
+    def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
+        return self.lock.acquire(blocking, timeout)
+
+    def release(self) -> None:
+        return self.lock.release()
+
+    def __enter__(self) -> bool:
+        return self.lock.__enter__()
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        return self.lock.__exit__(exc_type, exc_val, exc_tb)
+

--- a/aphrodite/v1/core/dynamic_kv/mem_info_tracker.py
+++ b/aphrodite/v1/core/dynamic_kv/mem_info_tracker.py
@@ -1,0 +1,72 @@
+import atexit
+import os
+import signal
+from typing import Optional
+
+import posix_ipc
+
+from .cli_utils import (MemInfoStruct, RwLockedShm, get_ipc_name, get_ipc_path,
+                        init_kv_cache_limit)
+from .utils import DEFAULT_IPC_NAME
+
+
+class MemInfoTracker:
+    """Tracks memory usage information through shared memory."""
+
+    def __init__(self, total_mem_size: int):
+        """
+        Args:
+            total_mem_size: Total memory size to initialize shared memory with
+        """
+        self.ipc_name = get_ipc_name(DEFAULT_IPC_NAME)
+        init_kv_cache_limit(self.ipc_name, total_mem_size)
+        self._register_cleanup()
+
+    def check_and_get_resize_target(self, current_mem_size: int,
+                                    num_layers: int) -> Optional[int]:
+        """Check if memory size has changed and return new target size if needed."""
+        with RwLockedShm(self.ipc_name, MemInfoStruct.SHM_SIZE,
+                         RwLockedShm.RLOCK) as mm:
+            mem_info = MemInfoStruct.from_buffer(mm)
+            new_mem_size = mem_info.total_size // num_layers // 2
+            if new_mem_size != current_mem_size:
+                return new_mem_size
+        return None
+
+    def update_memory_usage(self, used_size: int, prealloc_size: int):
+        """Update the memory usage information in shared memory."""
+        with RwLockedShm(self.ipc_name, MemInfoStruct.SHM_SIZE,
+                         RwLockedShm.WLOCK) as mm:
+            mem_info = MemInfoStruct.from_buffer(mm)
+            mem_info.used_size = used_size
+            mem_info.prealloc_size = prealloc_size
+            mem_info.write_to_buffer(mm)
+
+    def cleanup(self, *args):
+        """Remove the POSIX shared-memory segment and its backing file."""
+        try:
+            posix_ipc.unlink_shared_memory(self.ipc_name)
+        except Exception:
+            pass
+
+        try:
+            os.unlink(get_ipc_path(self.ipc_name))
+        except FileNotFoundError:
+            pass
+
+        if args and isinstance(args[0], int):
+            signum = args[0]
+            signal.signal(signum, signal.SIG_DFL)
+            os.kill(os.getpid(), signum)
+
+    def _register_cleanup(self):
+        """Register atexit and signal handlers for shared-memory cleanup."""
+        atexit.register(self.cleanup)
+
+        for _sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP,
+                     signal.SIGQUIT):
+            try:
+                signal.signal(_sig, self.cleanup)
+            except Exception:
+                pass
+

--- a/aphrodite/v1/core/dynamic_kv/page_allocator.py
+++ b/aphrodite/v1/core/dynamic_kv/page_allocator.py
@@ -1,0 +1,497 @@
+import threading
+from collections import deque
+from typing import List, Optional, Tuple, cast
+
+import torch
+
+from .locks import ConditionLike, LockLike, NoOpCondition, NoOpLock
+from .mem_info_tracker import MemInfoTracker
+from .tp_ipc_util import (broadcast_map_to_kv_tensors,
+                          broadcast_unmap_from_kv_tensors)
+from .utils import (CONTIGUOUS_LAYOUT, GPU_UTILIZATION, MAX_RESERVED_PAGES,
+                    MIN_RESERVED_PAGES, PAGE_PREALLOC_ENABLED, SANITY_CHECK)
+
+try:
+    from aphrodite.v1.core.dynamic_kv import vmm_ops
+    _vmm_ops_available = True
+except ImportError:
+    _vmm_ops_available = False
+
+from aphrodite.logger import init_logger
+
+logger = init_logger(__name__)
+
+PREALLOC_THREAD_TIMEOUT: float = 2.0
+
+
+class Page:
+
+    def __init__(self, page_id: int, page_size: int):
+        self.page_id = page_id
+        self.page_size = page_size
+
+        self.start_block: Optional[int] = None
+        self.end_block: Optional[int] = None
+        self.num_kv_blocks: Optional[int] = None
+        self.free_list: List[int] = []
+
+    def _require_init(self) -> None:
+        """Raise AssertionError if the page has not been initialised."""
+        assert self.start_block is not None, "Page not initialised"
+        assert self.end_block is not None, "Page not initialised"
+        assert self.num_kv_blocks is not None, "Page not initialised"
+
+    def init(self, block_mem_size: int) -> None:
+        self.start_block, self.end_block = self.get_block_range(
+            self.page_id, self.page_size, block_mem_size)
+
+        self.num_kv_blocks = self.end_block - self.start_block
+        self.free_list = list(range(self.start_block, self.end_block))
+
+    def alloc(self, num_blocks: int = 1) -> List[int]:
+        self._require_init()
+        if self.full():
+            raise ValueError(f"Page {self.page_id} is already full")
+        block_ids = self.free_list[:num_blocks]
+        self.free_list = self.free_list[num_blocks:]
+        return block_ids
+
+    def free(self, block_id: int) -> None:
+        self._require_init()
+        if SANITY_CHECK:
+            self._sanity_check(block_id)
+        self.free_list.append(block_id)
+
+    def free_batch(self, block_ids: List[int]) -> None:
+        self._require_init()
+        if SANITY_CHECK:
+            for block_id in block_ids:
+                self._sanity_check(block_id)
+        self.free_list.extend(block_ids)
+
+    def empty(self) -> bool:
+        self._require_init()
+        return len(self.free_list) == self.num_kv_blocks
+
+    def full(self) -> bool:
+        self._require_init()
+        return not self.free_list
+
+    def num_free_blocks(self) -> int:
+        self._require_init()
+        return len(self.free_list)
+
+    def get_free_blocks(self) -> List[int]:
+        self._require_init()
+        return self.free_list
+
+    def _has_block(self, block_id: int) -> bool:
+        self._require_init()
+        return block_id >= cast(int, self.start_block) and block_id < cast(
+            int, self.end_block)
+
+    def _sanity_check(self, block_id: int) -> None:
+        self._require_init()
+        if not self._has_block(block_id):
+            raise ValueError(
+                f"Page {self.page_id} does not have block {block_id}")
+        if block_id in self.free_list:
+            raise ValueError(f"Block {block_id} is already free")
+
+    @staticmethod
+    def get_block_range(page_id: int, page_size: int,
+                        block_mem_size: int) -> Tuple[int, int]:
+        """Get the block range of a page."""
+        start_block = (page_id * page_size + block_mem_size -
+                       1) // block_mem_size
+        end_block = ((page_id + 1) * page_size) // block_mem_size
+        return start_block, end_block
+
+    @staticmethod
+    def get_num_blocks(page_size: int, block_mem_size: int) -> int:
+        """Calculate the number of blocks that can fit in a page."""
+        return page_size // block_mem_size
+
+
+class PageAllocator:
+
+    def __init__(self,
+                 num_layers: int,
+                 mem_size_per_layer: int,
+                 page_size: int,
+                 tp_size: int = 1,
+                 async_sched: bool = False,
+                 contiguous_layout: bool = CONTIGUOUS_LAYOUT,
+                 enable_page_prealloc: bool = PAGE_PREALLOC_ENABLED):
+        """
+        Args:
+            num_layers: Number of layers (for physical memory calculation).
+            mem_size_per_layer: Memory size per layer per K/V tensor in bytes.
+            page_size: Page size in bytes.
+            tp_size: Tensor parallel size.
+            async_sched: Whether asynchronous scheduling is enabled.
+            contiguous_layout: Whether to use contiguous layout.
+            enable_page_prealloc: Whether to enable page preallocation.
+        """
+        logger.info(
+            f"Init kvcached KV cache allocator: "
+            f"num_layers={num_layers}, "
+            f"mem_size_per_layer={mem_size_per_layer//(1024*1024)}MB, "
+            f"total_mem_size={2 * num_layers * mem_size_per_layer//(1024*1024)}MB, "
+            f"page_size={page_size//(1024*1024)}MB, "
+            f"tp_size={tp_size}, "
+            f"async_sched={async_sched}, "
+            f"contiguous_layout={contiguous_layout}, "
+            f"enable_prealloc={enable_page_prealloc}")
+
+        self.num_layers = num_layers
+        self.mem_size_per_layer = mem_size_per_layer
+        self.page_size = page_size
+        self.tp_size = tp_size
+        self.async_sched = async_sched
+        self.contiguous_layout = contiguous_layout
+        self.gpu_utilization = GPU_UTILIZATION
+        self.num_free_pages = mem_size_per_layer // page_size
+        self.num_total_pages = mem_size_per_layer // page_size
+
+        self.free_page_list: deque[int] = deque(range(self.num_free_pages))
+
+        self.min_reserved_pages: int = MIN_RESERVED_PAGES
+        self.max_reserved_pages: int = MAX_RESERVED_PAGES
+        self.reserved_page_list: deque[int] = deque()
+
+        self.reclaimed_page_list: deque[int] = deque()
+
+        self.mem_info_tracker = MemInfoTracker(self.mem_size_per_layer *
+                                               num_layers * 2)
+
+        self.enable_page_prealloc: bool = enable_page_prealloc
+
+        self._lock: LockLike
+        self._cond: ConditionLike
+
+        if self.enable_page_prealloc:
+            self._lock = threading.RLock()
+            self._cond = threading.Condition(self._lock)
+        else:
+            self._lock = NoOpLock()
+            self._cond = NoOpCondition(self._lock)
+        self.prealloc_running: bool = False
+        self.prealloc_needed: bool = False
+        self.prealloc_thd: Optional[threading.Thread] = None
+
+    def __del__(self):
+        try:
+            if self.enable_page_prealloc and self.prealloc_thd is not None:
+                self._stop_prealloc_thread(timeout=PREALLOC_THREAD_TIMEOUT)
+        except Exception:
+            pass
+
+    def start_prealloc_thread(self):
+        if self.enable_page_prealloc:
+            self._lock = threading.RLock()
+            self._cond = threading.Condition(self._lock)
+            self._start_prealloc_thread()
+
+    def alloc_page(self) -> Page:
+        with self._lock:
+            page_id: Optional[int] = None
+
+            while page_id is None:
+                if self.reserved_page_list:
+                    page_id = self.reserved_page_list.popleft()
+                    self.num_free_pages -= 1
+
+                    if len(self.reserved_page_list) < self.min_reserved_pages:
+                        self.prealloc_needed = True
+                        self._cond.notify_all()
+
+                    self._update_memory_usage()
+                    return Page(page_id, self.page_size)
+
+                if self.free_page_list:
+                    page_id = self.free_page_list.popleft()
+                    self.num_free_pages -= 1
+                    break
+
+                if self.num_free_pages <= 0:
+                    raise ValueError("No free pages left")
+
+                if not self.enable_page_prealloc:
+                    raise RuntimeError(
+                        "Inconsistent page allocator state: no free pages "
+                        "available to allocate")
+
+                self._cond.wait()
+
+        assert page_id is not None
+
+        try:
+            self._map_pages([page_id])
+        except Exception as e:
+            with self._lock:
+                self.free_page_list.appendleft(page_id)
+                self.num_free_pages += 1
+                self._cond.notify_all()
+            raise RuntimeError(f"Failed to map page {page_id}: {e}") from e
+
+        if self.enable_page_prealloc:
+            self._trigger_preallocation()
+
+        self._update_memory_usage()
+        return Page(page_id, self.page_size)
+
+    def free_page(self, page_id: int) -> None:
+        with self._lock:
+            if SANITY_CHECK and (page_id in self.free_page_list
+                                 or page_id in self.reserved_page_list):
+                raise ValueError(f"Page {page_id} is already free or reserved")
+
+            self.num_free_pages += 1
+            if len(self.reserved_page_list) < self.max_reserved_pages:
+                self.reserved_page_list.append(page_id)
+                self._update_memory_usage()
+                self._cond.notify_all()
+                return
+
+        self._unmap_pages([page_id])
+        with self._lock:
+            self.free_page_list.append(page_id)
+            self._update_memory_usage()
+            self._cond.notify_all()
+
+    def free_pages(self, page_ids: List[int]) -> None:
+        with self._lock:
+            if SANITY_CHECK:
+                for page_id in page_ids:
+                    if (page_id in self.free_page_list
+                            or page_id in self.reserved_page_list):
+                        raise ValueError(
+                            f"Page {page_id} is already free or reserved")
+
+            self.num_free_pages += len(page_ids)
+            num_to_reserve = self.max_reserved_pages - len(
+                self.reserved_page_list)
+            if num_to_reserve > 0:
+                self.reserved_page_list.extend(page_ids[:num_to_reserve])
+                self._cond.notify_all()
+                page_ids = page_ids[num_to_reserve:]
+
+        if len(page_ids) == 0:
+            self._update_memory_usage()
+            return
+
+        self._unmap_pages(page_ids)
+        with self._lock:
+            self.free_page_list.extend(page_ids)
+            self._update_memory_usage()
+            self._cond.notify_all()
+
+    def resize(self, new_mem_size: int) -> bool:
+        new_num_pages = new_mem_size // self.page_size
+        with self._lock:
+            if new_num_pages < self.get_num_inuse_pages():
+                return False
+            if new_num_pages == self.num_total_pages:
+                return True
+            elif new_num_pages > self.num_total_pages:
+                num_to_expand = new_num_pages - self.num_total_pages
+
+                num_to_reuse = min(len(self.reclaimed_page_list),
+                                   num_to_expand)
+                if num_to_reuse > 0:
+                    for _ in range(num_to_reuse):
+                        self.free_page_list.append(
+                            self.reclaimed_page_list.popleft())
+                    num_to_expand -= num_to_reuse
+                    self.num_free_pages += num_to_reuse
+
+                if num_to_expand > 0:
+                    new_page_ids = list(
+                        range(self.num_total_pages,
+                              self.num_total_pages + num_to_expand))
+                    self.free_page_list.extend(new_page_ids)
+                    self.num_free_pages += num_to_expand
+                self.num_total_pages = new_num_pages
+                self._update_memory_usage()
+            else:
+                num_to_reclaim = self.num_total_pages - new_num_pages
+
+                if len(self.free_page_list) < num_to_reclaim:
+                    reserved_count = len(self.reserved_page_list)
+                    if reserved_count > 0:
+                        pages_to_unmap = list(self.reserved_page_list)
+                        self.reserved_page_list.clear()
+                        try:
+                            self._lock.release()
+                            self._unmap_pages(pages_to_unmap)
+                        finally:
+                            self._lock.acquire()
+                        self.free_page_list.extend(pages_to_unmap)
+                        self._update_memory_usage()
+
+                if len(self.free_page_list) < num_to_reclaim:
+                    return False
+
+                for _ in range(num_to_reclaim):
+                    self.reclaimed_page_list.append(self.free_page_list.pop())
+                self.num_free_pages -= num_to_reclaim
+                self.num_total_pages = new_num_pages
+        return True
+
+    def trim(self) -> None:
+        with self._lock:
+            pages_to_unmap = list(self.reserved_page_list)
+            self.reserved_page_list.clear()
+
+            if not pages_to_unmap:
+                self._update_memory_usage()
+                return
+
+            try:
+                self._lock.release()
+                self._unmap_pages(pages_to_unmap)
+            finally:
+                self._lock.acquire()
+
+            self.free_page_list.extend(pages_to_unmap)
+            self._update_memory_usage()
+
+    def get_num_free_pages(self) -> int:
+        return self.num_free_pages
+
+    def get_num_inuse_pages(self) -> int:
+        return self.num_total_pages - self.num_free_pages
+
+    def get_num_total_pages(self) -> int:
+        return self.num_total_pages
+
+    def get_num_reserved_pages(self) -> int:
+        with self._lock:
+            return len(self.reserved_page_list)
+
+    def get_avail_physical_pages(self) -> int:
+        avail_phy_mem_size, total_phy_mem_size = torch.cuda.mem_get_info()
+        headroom = int(total_phy_mem_size * (1 - self.gpu_utilization))
+        avail_phy_mem_size = max(avail_phy_mem_size - headroom, 0)
+
+        avail_phy_pages = avail_phy_mem_size // self.page_size
+        avail_pages_per_layer = avail_phy_pages // self.num_layers // 2
+        return int(avail_pages_per_layer)
+
+    def get_page_id(self, block_id: int, block_mem_size: int) -> int:
+        return block_id * block_mem_size // self.page_size
+
+    def _prealloc_worker(self):
+        """Worker thread that preallocates and maps physical pages."""
+        while self.prealloc_running:
+            with self._lock:
+                while not self.prealloc_needed and self.prealloc_running:
+                    self._cond.wait()
+
+                if not self.prealloc_running:
+                    break
+
+                self.prealloc_needed = False
+                current_reserved = len(self.reserved_page_list)
+                to_reserve = max(0, self.min_reserved_pages - current_reserved)
+                to_reserve = min(to_reserve, len(self.free_page_list),
+                                 self.get_avail_physical_pages())
+                if to_reserve <= 0:
+                    continue
+
+                pages_to_reserve = []
+
+                for _ in range(to_reserve):
+                    if self.free_page_list:
+                        pages_to_reserve.append(self.free_page_list.popleft())
+                    else:
+                        break
+
+            if pages_to_reserve:
+                try:
+                    self._map_pages(pages_to_reserve)
+                    with self._lock:
+                        self.reserved_page_list.extend(pages_to_reserve)
+                        self._update_memory_usage()
+                        self._cond.notify_all()
+                    logger.debug(
+                        f"Preallocated {len(pages_to_reserve)} pages, "
+                        f"reserved={len(self.reserved_page_list)}")
+                except Exception as e:
+                    with self._lock:
+                        self.free_page_list.extendleft(pages_to_reserve)
+                        self._cond.notify_all()
+                    logger.error(
+                        f"Failed to preallocate {len(pages_to_reserve)} pages: "
+                        f"{e}")
+
+    def _start_prealloc_thread(self):
+        if self.prealloc_thd is None:
+            self.prealloc_running = True
+            self.prealloc_thd = threading.Thread(target=self._prealloc_worker,
+                                                 daemon=True)
+            self.prealloc_thd.start()
+
+            self._trigger_preallocation()
+
+    def _stop_prealloc_thread(self, timeout: Optional[float] = None):
+        if self.prealloc_thd is not None:
+            with self._lock:
+                self.prealloc_running = False
+                self._cond.notify_all()
+            self.prealloc_thd.join(timeout)
+            if self.prealloc_thd.is_alive():
+                logger.warning(
+                    "Preallocation thread did not stop within timeout")
+            self.prealloc_thd = None
+            logger.debug("Stopped page preallocation thread")
+
+    def _trigger_preallocation(self):
+        """Trigger the preallocation thread to fill up reserved blocks"""
+        with self._lock:
+            self.prealloc_needed = True
+            self._cond.notify_all()
+
+    def _map_pages(self, page_ids: list[int]) -> None:
+        if not _vmm_ops_available:
+            return
+        
+        if self.contiguous_layout:
+            offsets = [
+                pid * self.page_size * self.num_layers * 2 for pid in page_ids
+            ]
+        else:
+            offsets = [pid * self.page_size for pid in page_ids]
+        if self.tp_size > 1:
+            broadcast_map_to_kv_tensors(self.tp_size, offsets)
+        else:
+            vmm_ops.map_to_kv_tensors(offsets)
+
+    def _unmap_pages(self, page_ids: list[int]) -> None:
+        if not _vmm_ops_available:
+            return
+        
+        if self.contiguous_layout:
+            offsets = [
+                pid * self.page_size * self.num_layers * 2 for pid in page_ids
+            ]
+        else:
+            offsets = [pid * self.page_size for pid in page_ids]
+        if self.tp_size > 1:
+            broadcast_unmap_from_kv_tensors(self.tp_size, offsets)
+        else:
+            if self.async_sched:
+                torch.cuda.synchronize()
+            vmm_ops.unmap_from_kv_tensors(offsets)
+
+    def _update_memory_usage(self):
+        """Update memory usage information in shared memory."""
+        used_phy_mem_size = (self.get_num_inuse_pages() * self.num_layers *
+                             self.page_size * 2)
+        prealloc_phy_mem_size = (self.get_num_reserved_pages() *
+                                 self.num_layers * self.page_size * 2)
+
+        self.mem_info_tracker.update_memory_usage(
+            used_size=used_phy_mem_size, prealloc_size=prealloc_phy_mem_size)
+

--- a/aphrodite/v1/core/dynamic_kv/tp_ipc_util.py
+++ b/aphrodite/v1/core/dynamic_kv/tp_ipc_util.py
@@ -1,0 +1,192 @@
+import asyncio
+import os
+import pickle
+import socket
+import threading
+from typing import Any, Dict, cast
+
+try:
+    from aphrodite.v1.core.dynamic_kv import vmm_ops
+    _vmm_ops_available = True
+except ImportError:
+    _vmm_ops_available = False
+
+SOCKET_DIR = "/tmp/kvcached-ipc"
+
+
+def get_worker_socket_path(rank: int) -> str:
+    """Get the path for the worker socket."""
+    return os.path.join(SOCKET_DIR, f"worker_{rank}.sock")
+
+
+Message = Dict[str, Any]
+
+
+def send_msg(sock: socket.socket, msg: Message) -> None:
+    """Send a message through the socket."""
+    data = pickle.dumps(msg)
+    sock.sendall(len(data).to_bytes(4, 'big') + data)
+
+
+def recv_msg(sock: socket.socket) -> Message:
+    """Receive a message from the socket."""
+    length_bytes = sock.recv(4)
+    if not length_bytes:
+        raise ConnectionError("Socket connection closed")
+    if not len(length_bytes) == 4:
+        raise ValueError("Received incomplete length bytes from socket")
+    length = int.from_bytes(length_bytes, 'big')
+    if length <= 0:
+        raise ValueError("Received invalid length for message")
+    data = b""
+    while len(data) < length:
+        chunk = sock.recv(length - len(data))
+        if not chunk:
+            raise ConnectionError(
+                "Socket connection closed while receiving data")
+        data += chunk
+    if len(data) != length:
+        raise ValueError("Received data length does not match expected length")
+    return cast(Message, pickle.loads(data))
+
+
+def start_worker_listener_thread(rank: int):
+    """Start a thread that listens for messages on the worker socket."""
+    if not _vmm_ops_available:
+        raise RuntimeError("vmm_ops module not available")
+    
+    os.makedirs(SOCKET_DIR, exist_ok=True)
+    socket_path = get_worker_socket_path(rank)
+
+    if os.path.exists(socket_path):
+        try:
+            os.remove(socket_path)
+        except OSError as e:
+            print(f"Error removing existing socket file {socket_path}: {e}")
+
+    server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server_sock.bind(socket_path)
+    server_sock.listen()
+
+    def listen_loop():
+        print(f"Worker {rank} IPC listener started at {socket_path}")
+        while True:
+            conn, _ = server_sock.accept()
+            try:
+                msg: Message = recv_msg(conn)
+                if msg["cmd"] == "map_to_kv_tensors":
+                    vmm_ops.map_to_kv_tensors(msg["offsets"])
+                    send_msg(conn, {"status": "success"})
+                elif msg["cmd"] == "unmap_from_kv_tensors":
+                    vmm_ops.unmap_from_kv_tensors(msg["offsets"])
+                    send_msg(conn, {"status": "success"})
+                elif msg["cmd"] == "kv_tensors_created":
+                    created: bool = vmm_ops.kv_tensors_created()
+                    send_msg(conn, {"status": "success", "created": created})
+                else:
+                    send_msg(conn, {
+                        "status": "error",
+                        "message": "Unknown command"
+                    })
+            except Exception as e:
+                print(f"Worker {rank} error processing message: {e}")
+                send_msg(conn, {"status": "error", "message": str(e)})
+            finally:
+                conn.close()
+
+    t = threading.Thread(target=listen_loop, daemon=True)
+    t.start()
+
+
+async def _send_and_receive_message(rank: int, message: Message) -> Message:
+    """Send a message to the worker and receive a response asynchronously."""
+    socket_path = get_worker_socket_path(rank)
+    reader, writer = await asyncio.open_unix_connection(socket_path)
+
+    try:
+        data = pickle.dumps(message)
+        writer.write(len(data).to_bytes(4, 'big') + data)
+        await writer.drain()
+
+        length_bytes = await reader.readexactly(4)
+        length = int.from_bytes(length_bytes, 'big')
+
+        data = await reader.readexactly(length)
+        return cast(Message, pickle.loads(data))
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
+async def _broadcast_map_to_kv_tensors(tp_size: int,
+                                       offsets: list[int]) -> None:
+    """Broadcast the "map_to_kv_tensors" operation to all workers concurrently."""
+    map_message = {"cmd": "map_to_kv_tensors", "offsets": offsets}
+    tasks = [
+        _send_and_receive_message(rank, map_message) for rank in range(tp_size)
+    ]
+
+    responses = await asyncio.gather(*tasks, return_exceptions=True)
+    for rank, response in enumerate(responses):
+        if isinstance(response, Exception):
+            raise RuntimeError(f"Worker {rank} failed to map: {response}")
+        elif not isinstance(response,
+                            dict) or response.get("status") != "success":
+            raise RuntimeError(f"Worker {rank} failed to map: {response}")
+
+
+async def _broadcast_unmap_from_kv_tensors(tp_size: int,
+                                           offsets: list[int]) -> None:
+    """Broadcast the "unmap_from_kv_tensors" operation to all workers concurrently."""
+    unmap_message = {"cmd": "unmap_from_kv_tensors", "offsets": offsets}
+    tasks = [
+        _send_and_receive_message(rank, unmap_message)
+        for rank in range(tp_size)
+    ]
+
+    responses = await asyncio.gather(*tasks, return_exceptions=True)
+    for rank, response in enumerate(responses):
+        if isinstance(response, Exception):
+            raise RuntimeError(f"Worker {rank} failed to unmap: {response}")
+        elif not isinstance(response,
+                            dict) or response.get("status") != "success":
+            raise RuntimeError(f"Worker {rank} failed to unmap: {response}")
+
+
+async def _broadcast_kv_tensors_created(tp_size: int) -> bool:
+    """Broadcast the "kv_tensors_created" operation to all workers concurrently."""
+    check_message = {"cmd": "kv_tensors_created"}
+    tasks = [
+        _send_and_receive_message(rank, check_message)
+        for rank in range(tp_size)
+    ]
+
+    responses = await asyncio.gather(*tasks, return_exceptions=True)
+    all_created = True
+    for rank, response in enumerate(responses):
+        if isinstance(response, Exception):
+            raise RuntimeError(
+                f"Worker {rank} failed to check KV tensors created: {response}"
+            )
+        elif not isinstance(response,
+                            dict) or response.get("status") != "success":
+            raise RuntimeError(
+                f"Worker {rank} failed to check KV tensors created: {response}"
+            )
+        elif not response.get("created", False):
+            all_created = False
+
+    return all_created
+
+
+def broadcast_map_to_kv_tensors(tp_size: int, offsets: list[int]) -> None:
+    asyncio.run(_broadcast_map_to_kv_tensors(tp_size, offsets))
+
+
+def broadcast_unmap_from_kv_tensors(tp_size: int, offsets: list[int]) -> None:
+    asyncio.run(_broadcast_unmap_from_kv_tensors(tp_size, offsets))
+
+
+def broadcast_kv_tensors_created(tp_size: int) -> bool:
+    return asyncio.run(_broadcast_kv_tensors_created(tp_size))
+

--- a/aphrodite/v1/core/dynamic_kv/utils.py
+++ b/aphrodite/v1/core/dynamic_kv/utils.py
@@ -1,0 +1,107 @@
+import os
+
+
+def _sanitize_segment(segment: str) -> str:
+    """Sanitize a segment to safe characters for SHM names."""
+    allowed = []
+    for ch in segment:
+        if ch.isalnum() or ch in ("_", "-"):
+            allowed.append(ch)
+        else:
+            allowed.append("-")
+    return "".join(allowed)[:64]
+
+def _ipc_segment_exists(name: str) -> bool:
+    """Return True if a shared-memory segment/file with this name exists."""
+    try:
+        return os.path.exists(os.path.join(SHM_DIR, name))
+    except Exception:
+        return False
+
+
+def _obtain_default_ipc_name() -> str:
+    """Return a default IPC name like kvcached_<Engine>_<PGID>."""
+    engine_tag = "aphrodite"
+    try:
+        group_id = os.getpgid(0)
+    except Exception:
+        try:
+            group_id = os.getsid(0)
+        except Exception:
+            group_id = os.getpid()
+
+    explicit = os.getenv("KVCACHED_IPC_NAME")
+    if explicit:
+        preferred = _sanitize_segment(explicit)
+
+        if not _ipc_segment_exists(preferred):
+            return preferred
+
+        base_candidate = f"{preferred}_{engine_tag}_{group_id}"
+        if not _ipc_segment_exists(base_candidate):
+            return base_candidate
+        for i in range(1, 100):
+            candidate = f"{base_candidate}_{i}"
+            if not _ipc_segment_exists(candidate):
+                return candidate
+        return f"{base_candidate}_{os.getpid()}"
+
+    base = "kvcached"
+    name = f"{base}_{engine_tag}_{group_id}"
+    if not _ipc_segment_exists(name):
+        return name
+    for i in range(1, 100):
+        candidate = f"{name}_{i}"
+        if not _ipc_segment_exists(candidate):
+            return candidate
+    return f"{name}_{os.getpid()}"
+
+
+def _get_page_size() -> int:
+    """Get PAGE_SIZE from environment variable with validation."""
+    default_page_size = 2 * 1024 * 1024
+    page_size_mb_str = os.getenv("KVCACHED_PAGE_SIZE_MB")
+
+    if page_size_mb_str is None:
+        return default_page_size
+
+    try:
+        page_size = int(page_size_mb_str) * 1024 * 1024
+    except ValueError:
+        raise ValueError(
+            f"Invalid KVCACHED_PAGE_SIZE_MB: {page_size_mb_str}. Must be an integer."
+        )
+
+    base_size = 2 * 1024 * 1024
+    if page_size <= 0 or page_size % base_size != 0:
+        raise ValueError(
+            f"PAGE_SIZE must be a positive multiple of 2MB (2097152 bytes), "
+            f"got: {page_size}")
+
+    return page_size
+
+
+PAGE_SIZE = _get_page_size()
+
+GPU_UTILIZATION = float(os.getenv("KVCACHED_GPU_UTILIZATION", "0.95"))
+PAGE_PREALLOC_ENABLED = os.getenv("KVCACHED_PAGE_PREALLOC_ENABLED",
+                                  "true").lower() == "true"
+MIN_RESERVED_PAGES = int(os.getenv("KVCACHED_MIN_RESERVED_PAGES", "5"))
+MAX_RESERVED_PAGES = int(os.getenv("KVCACHED_MAX_RESERVED_PAGES", "10"))
+SANITY_CHECK = os.getenv("KVCACHED_SANITY_CHECK", "false").lower() == "true"
+CONTIGUOUS_LAYOUT = os.getenv("KVCACHED_CONTIGUOUS_LAYOUT",
+                              "true").lower() == "true"
+
+DEFAULT_IPC_NAME = _obtain_default_ipc_name()
+SHM_DIR = "/dev/shm"
+
+
+def align_to(x: int, a: int) -> int:
+    return (x + a - 1) // a * a
+
+
+def align_up_to_page(n_cells: int, cell_size: int) -> int:
+    n_cells_per_page = PAGE_SIZE // cell_size
+    aligned_n_cells = align_to(n_cells, n_cells_per_page)
+    return aligned_n_cells
+

--- a/aphrodite/v1/core/dynamic_kv/vmm_ops.py
+++ b/aphrodite/v1/core/dynamic_kv/vmm_ops.py
@@ -1,0 +1,38 @@
+"""Python wrapper for VMM (Virtual Memory Management) operations."""
+
+from typing import List
+
+import torch
+
+import aphrodite._custom_ops as ops
+
+
+def init_kvcached(dev_str: str, page_size: int, contiguous_layout: bool) -> None:
+    """Initialize the kvcached VMM system."""
+    ops.init_kvcached(dev_str, page_size, contiguous_layout)
+
+
+def shutdown_kvcached() -> None:
+    """Shutdown the kvcached VMM system."""
+    ops.shutdown_kvcached()
+
+
+def create_kv_tensors(size: int, dtype_size: int, dev_str: str, num_layers: int) -> List[torch.Tensor]:
+    """Create KV cache tensors with virtual memory backing."""
+    return ops.create_kv_tensors(size, dtype_size, dev_str, num_layers)
+
+
+def kv_tensors_created() -> bool:
+    """Check if KV tensors have been created."""
+    return ops.kv_tensors_created()
+
+
+def map_to_kv_tensors(offsets: List[int]) -> None:
+    """Map physical memory pages to KV tensors at given offsets."""
+    ops.map_to_kv_tensors(offsets)
+
+
+def unmap_from_kv_tensors(offsets: List[int]) -> None:
+    """Unmap physical memory pages from KV tensors at given offsets."""
+    ops.unmap_from_kv_tensors(offsets)
+

--- a/aphrodite/v1/engine/core.py
+++ b/aphrodite/v1/engine/core.py
@@ -106,6 +106,15 @@ class EngineCore:
 
         self.structured_output_manager = StructuredOutputManager(aphrodite_config)
 
+        is_elastic = envs.APHRODITE_ENABLE_DYNAMIC_KV_CACHE
+        if is_elastic:
+            from aphrodite.v1.core.dynamic_kv.interfaces import init_kvcached
+            init_kvcached(
+                tp_rank=0,
+                tp_size=aphrodite_config.parallel_config.tensor_parallel_size,
+                is_worker=False,
+            )
+
         # Setup scheduler.
         if isinstance(aphrodite_config.scheduler_config.scheduler_cls, str):
             Scheduler = resolve_obj_by_qualname(

--- a/aphrodite/v1/worker/gpu_model_runner.py
+++ b/aphrodite/v1/worker/gpu_model_runner.py
@@ -420,6 +420,22 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             dtype=np.int64,
         )
 
+        self.is_elastic = envs.APHRODITE_ENABLE_DYNAMIC_KV_CACHE
+        if self.is_elastic:
+            import aphrodite.v1.core.dynamic_kv.interfaces as kvcached_ifaces
+
+            self.kvcached_interfaces = kvcached_ifaces
+            # Get tensor parallel rank and size from Aphrodite's parallel state
+            from aphrodite.distributed.parallel_state import (
+                get_tensor_model_parallel_rank,
+                get_tensor_model_parallel_world_size)
+            tp_rank = get_tensor_model_parallel_rank()
+            tp_size = get_tensor_model_parallel_world_size()
+            kvcached_ifaces.init_kvcached(tp_rank=tp_rank,
+                                          tp_size=tp_size,
+                                          is_worker=True,
+                                          device=str(self.device))
+
         # Layer pairings for cross-layer KV sharing.
         # If an Attention layer `layer_name` is in the keys of this dict, it
         # means this layer will perform attention using the keys and values
@@ -3870,10 +3886,9 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         show_progress = is_global_first_rank() and self.load_config.use_tqdm_on_load
 
         if show_progress:
-            from rich.progress import (
-                Progress, BarColumn, TextColumn, 
-                TimeElapsedColumn, MofNCompleteColumn
-            )
+            from rich.progress import (BarColumn, MofNCompleteColumn, Progress,
+                                       TextColumn, TimeElapsedColumn)
+
             from aphrodite.utils import get_progress_log_prefix
 
             desc = "Capturing CUDA graphs ({}, {})".format(
@@ -4529,10 +4544,13 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             kv_cache_config, kv_cache_raw_tensors
         )
 
-        # Set up cross-layer KV cache sharing
-        for layer_name, target_layer_name in self.shared_kv_cache_layers.items():
-            logger.debug("%s reuses KV cache of %s", layer_name, target_layer_name)
-            kv_caches[layer_name] = kv_caches[target_layer_name]
+        if self.is_elastic:
+            kv_caches = self._allocate_kv_cache_from_kvcached(kv_cache_config)
+        else:
+            # Set up cross-layer KV cache sharing
+            for layer_name, target_layer_name in self.shared_kv_cache_layers.items():
+                logger.debug("%s reuses KV cache of %s", layer_name, target_layer_name)
+                kv_caches[layer_name] = kv_caches[target_layer_name]
 
         num_attn_module = (
             2 if self.model_config.hf_config.model_type == "longcat_flash" else 1
@@ -4683,3 +4701,80 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.transfer_event.record()
         self.transfer_event.synchronize()
         return pinned.tolist()
+
+
+    def _allocate_kv_cache_from_kvcached(
+            self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
+        """Allocate raw KV-cache buffers via the *kvcached* backend.
+        Returns a flat list whose order corresponds to
+        `kv_cache_group.layer_names`.
+        """
+        if self.shared_kv_cache_layers:
+            raise NotImplementedError(
+                "kvcached does not support cross layer KV sharing yet.")
+
+        if len(kv_cache_config.kv_cache_groups) > 1:
+            raise NotImplementedError(
+                "kvcached does not support hybrid models with more than one "
+                "KV cache type yet.")
+
+        kv_cache_group = kv_cache_config.kv_cache_groups[0]
+        kv_cache_spec = kv_cache_group.kv_cache_spec
+        if not isinstance(kv_cache_spec, FullAttentionSpec):
+            raise NotImplementedError(
+                "kvcached only supports FullAttentionSpec layers for now.")
+
+        # Build a lookup: layer_name -> KVCacheTensor config for quick access.
+        from aphrodite.v1.kv_cache_interface import KVCacheTensor
+        layer_to_tensor_cfg: dict[str, KVCacheTensor] = {}
+        for tensor_cfg in kv_cache_config.kv_cache_tensors:
+            for ln in tensor_cfg.shared_by:
+                layer_to_tensor_cfg[ln] = tensor_cfg
+
+        # Validate sizes and derive representative num_blocks.
+        for layer_name in kv_cache_group.layer_names:
+            tensor_cfg = layer_to_tensor_cfg[layer_name]
+            assert (tensor_cfg.size % kv_cache_spec.page_size_bytes == 0), (
+                f"Tensor size for layer {layer_name} ({tensor_cfg.size}) "
+                "is not a multiple of page size "
+                f"{kv_cache_spec.page_size_bytes}.")
+            num_blocks = tensor_cfg.size // kv_cache_spec.page_size_bytes
+            assert num_blocks >= kv_cache_config.num_blocks, (
+                "Number of blocks derived from tensor size is smaller than "
+                "kv_cache_config.num_blocks")
+
+        # Use the first layer as representative for `num_blocks` in shape calc.
+        first_layer_name = kv_cache_group.layer_names[0]
+        rep_tensor_cfg = layer_to_tensor_cfg[first_layer_name]
+        num_blocks = rep_tensor_cfg.size // kv_cache_spec.page_size_bytes
+
+        # Attention backend for this group is the first one initialised in
+        # `initialize_attn_backend()` which must have been called already.
+        attn_backend = self.attn_groups[0][0].backend
+        kv_cache_shape = attn_backend.get_kv_cache_shape(
+            num_blocks,
+            kv_cache_spec.block_size,
+            kv_cache_spec.num_kv_heads,
+            kv_cache_spec.head_size,
+        )
+
+        num_layers = len(kv_cache_group.layer_names)
+        dtype = kv_cache_spec.dtype
+        kv_cache_buffers = self.kvcached_interfaces.alloc_kv_cache(
+            kv_cache_shape,
+            kv_cache_spec.block_size,
+            dtype,
+            self.device.type,
+            num_layers,
+            attention_type="MHA",
+            kv_layout="NHD",
+        )
+
+        # Create layer_name -> tensor mapping from raw buffers.
+        kv_cache_group = kv_cache_config.kv_cache_groups[0]
+
+        kv_caches: dict[str, torch.Tensor] = {}
+        for idx, layer_name in enumerate(kv_cache_group.layer_names):
+            kv_caches[layer_name] = kv_cache_buffers[idx]
+
+        return kv_caches

--- a/kernels/vmm/allocator.cpp
+++ b/kernels/vmm/allocator.cpp
@@ -1,0 +1,278 @@
+#include <memory>
+#include <mutex>
+#include <torch/all.h>
+#include <unordered_map>
+
+#include "allocator.hpp"
+#include "constants.hpp"
+#include "cuda_utils.hpp"
+#include "ftensor.hpp"
+#include "page.hpp"
+#include "torch_utils.hpp"
+
+namespace aphrodite {
+namespace vmm {
+
+size_t kPageSize = 2 * 1024 * 1024;
+
+std::unique_ptr<FTensorAllocator> FTensorAllocator::g_allocator_;
+std::mutex FTensorAllocator::g_allocator_mutex_;
+
+static inline std::shared_ptr<Page> make_shared_page(const torch::Device &dev,
+                                                     page_id_t page_id) {
+  if (dev.is_cuda()) {
+    return std::make_shared<GPUPage>(page_id, dev.index());
+  } else if (dev.is_cpu()) {
+    return std::make_shared<CPUPage>(page_id);
+  }
+  ASSERT(false, "Unsupported device type.");
+  return nullptr;
+}
+
+static inline size_t get_v_base_offset(const torch::Tensor &tensor) {
+  size_t num_eles = tensor.numel() * tensor.element_size();
+  ASSERT(num_eles % (2 * kPageSize) == 0,
+         "Invalid tensor size: %zu, must be a multiple of 2 * page size %zu",
+         num_eles, 2 * kPageSize);
+  return num_eles / 2;
+}
+
+FTensorAllocator::FTensorAllocator(const torch::Device &device,
+                                   bool contiguous_layout)
+    : dev_(device), num_layers_(0), contiguous_layout_(contiguous_layout),
+      kv_tensor_size_per_layer_(0) {
+  if (dev_.is_cuda()) {
+    init_cuda_();
+  }
+}
+
+FTensorAllocator::~FTensorAllocator() { destroy(); }
+
+void FTensorAllocator::destroy() {
+  std::lock_guard<std::mutex> lock(mtx_);
+  ftensors_.clear();
+  contiguous_kv_tensor_.reset();
+  zero_page_.reset();
+}
+
+void FTensorAllocator::init(const std::string &dev_str, size_t page_size,
+                            bool contiguous_layout) {
+  std::lock_guard<std::mutex> lock(g_allocator_mutex_);
+  if (g_allocator_) {
+    LOGE("FTensorAllocator has been initialized. Re-initializing...")
+    g_allocator_.reset();
+  }
+
+  if (page_size > 0) {
+    size_t base_size = 2 * 1024 * 1024;
+    if (page_size % base_size != 0) {
+      LOGE("Invalid page size: %zu, must be a multiple of 2MB (2097152 bytes)",
+           page_size);
+      abort();
+    }
+    kPageSize = page_size;
+  }
+
+  auto device = torch::Device(dev_str);
+  g_allocator_ = std::make_unique<FTensorAllocator>(device, contiguous_layout);
+}
+
+FTensorAllocator *FTensorAllocator::global_allocator() {
+  std::lock_guard<std::mutex> lock(g_allocator_mutex_);
+  assert(g_allocator_);
+  return g_allocator_.get();
+}
+
+void FTensorAllocator::shutdown() {
+  std::lock_guard<std::mutex> lock(g_allocator_mutex_);
+  if (g_allocator_) {
+    g_allocator_.reset();
+  }
+}
+
+std::vector<torch::Tensor>
+FTensorAllocator::create_kv_tensors(size_t size, torch::Dtype dtype,
+                                    const std::string &dev_str,
+                                    int64_t num_layers) {
+  std::lock_guard<std::mutex> lock(mtx_);
+
+  assert(num_layers_ == 0 || num_layers_ == num_layers);
+  num_layers_ = num_layers;
+  size_t aligned_size = size;
+  if (size % kPageSize != 0) {
+    aligned_size = ((size + kPageSize - 1) / kPageSize) * kPageSize;
+    LOGW("Size %zu is not aligned to page size %zu, aligning to %zu", size,
+         kPageSize, aligned_size);
+  }
+  kv_tensor_size_per_layer_ = aligned_size;
+
+  if (contiguous_layout_) {
+    kPageSize *= num_layers * 2;
+    zero_page_ = make_shared_page(dev_, ZERO_PAGE_ID);
+    return create_kv_tensors_contiguous_(aligned_size, dtype, dev_str,
+                                         num_layers);
+  } else {
+    zero_page_ = make_shared_page(dev_, ZERO_PAGE_ID);
+    return create_kv_tensors_per_layer_(kv_prefix, aligned_size, dtype, dev_str,
+                                        num_layers);
+  }
+}
+
+bool FTensorAllocator::kv_tensors_created() {
+  std::lock_guard<std::mutex> lock(mtx_);
+  return num_layers_ > 0;
+}
+
+bool FTensorAllocator::map_to_kv_tensors(const std::vector<offset_t> &offsets) {
+  std::unique_lock<std::mutex> lock(mtx_);
+  if (num_layers_ == 0) {
+    LOGE("try to map to KV tensors when KV tensors are not created");
+    return false;
+  }
+
+  if (contiguous_layout_) {
+    auto ftensor = contiguous_kv_tensor_.get();
+    auto tensor = ftensor->get_tensor();
+
+    for (auto offset : offsets) {
+      ftensor->map(offset);
+    }
+  } else {
+    for (int64_t i = 0; i < num_layers_; i++) {
+      auto kv_name = std::string(kv_prefix) + std::to_string(i);
+      auto ftensor = ftensors_[kv_name].get();
+      auto tensor = ftensor->get_tensor();
+      auto v_base_offset = get_v_base_offset(tensor);
+      for (auto offset : offsets) {
+        auto koffset = offset;
+        auto voffset = offset + v_base_offset;
+        ftensor->map(koffset);
+        ftensor->map(voffset);
+      }
+    }
+  }
+  return true;
+}
+
+bool FTensorAllocator::unmap_from_kv_tensors(
+    const std::vector<offset_t> &offsets) {
+  std::unique_lock<std::mutex> lock(mtx_);
+  if (num_layers_ == 0) {
+    LOGE("try to unmap from KV tensors when KV tensors are not created");
+    return false;
+  }
+
+  if (contiguous_layout_) {
+    auto ftensor = contiguous_kv_tensor_.get();
+    auto tensor = ftensor->get_tensor();
+
+    for (auto offset : offsets) {
+      ftensor->unmap(offset);
+    }
+  } else {
+    for (int64_t i = 0; i < num_layers_; i++) {
+      auto kv_name = std::string(kv_prefix) + std::to_string(i);
+      auto ftensor = ftensors_[kv_name].get();
+      auto tensor = ftensor->get_tensor();
+      auto v_base_offset = get_v_base_offset(tensor);
+      for (auto offset : offsets) {
+        ftensor->unmap(offset);
+        ftensor->unmap(offset + v_base_offset);
+      }
+    }
+  }
+  return true;
+}
+
+std::string FTensorAllocator::get_anon_tensor_name_() {
+  static constexpr std::string_view prefix = "anon_tensor_";
+  static std::atomic<int> counter(0);
+  return std::string(prefix) + std::to_string(counter++);
+}
+
+std::vector<torch::Tensor> FTensorAllocator::create_kv_tensors_per_layer_(
+    std::string_view prefix, size_t size, torch::Dtype dtype,
+    const std::string &dev_str, int64_t num_layers) {
+  std::vector<torch::Tensor> ftensors;
+  for (int64_t i = 0; i < num_layers; i++) {
+    auto name = std::string(prefix) + std::to_string(i);
+    auto tensor = create_ftensor_(size, dtype, dev_str, name);
+    ftensors.push_back(tensor);
+  }
+  return ftensors;
+}
+
+std::vector<torch::Tensor>
+FTensorAllocator::create_kv_tensors_contiguous_(size_t size, torch::Dtype dtype,
+                                                const std::string &dev_str,
+                                                int64_t num_layers) {
+  size_t total_kv_size = size * num_layers;
+
+  auto contiguous_name = std::string(kv_prefix) + "contiguous";
+  contiguous_kv_tensor_ = std::make_unique<FTensor>(
+      contiguous_name, total_kv_size, dtype, dev_, zero_page_);
+
+  auto contiguous_tensor = contiguous_kv_tensor_->get_tensor();
+  return {contiguous_tensor};
+}
+
+torch::Tensor FTensorAllocator::create_ftensor_(size_t size, torch::Dtype dtype,
+                                                const std::string &dev_str,
+                                                std::string name) {
+  if (name.empty())
+    name = get_anon_tensor_name_();
+
+  if (ftensors_.find(name) != ftensors_.end()) {
+    auto tensor = ftensors_[name].get()->get_tensor();
+    assert(tensor.numel() * tensor.element_size() == size);
+    assert(tensor.device() == torch::Device(dev_str));
+    return tensor;
+  }
+
+  ftensors_[name] =
+      std::make_unique<FTensor>(name, size, dtype, dev_, zero_page_);
+  return ftensors_[name]->get_tensor();
+}
+
+void FTensorAllocator::free_ftensor_(torch::Tensor &ftensor) {
+  auto name = ftensor.name();
+  if (ftensors_.find(name) == ftensors_.end()) {
+    return;
+  }
+  ftensors_.erase(name);
+}
+
+void FTensorAllocator::init_cuda_() {
+  CHECK_RT(cudaFree(0));
+
+  CUdevice dev;
+  CHECK_DRV(cuCtxGetDevice(&dev));
+
+  int supportsVMM = 0;
+  CHECK_DRV(cuDeviceGetAttribute(
+      &supportsVMM, CU_DEVICE_ATTRIBUTE_VIRTUAL_ADDRESS_MANAGEMENT_SUPPORTED,
+      dev));
+
+  CUcontext context;
+  CHECK_DRV(cuCtxGetCurrent(&context));
+
+  CUmemAllocationProp prop{
+      .type = CU_MEM_ALLOCATION_TYPE_PINNED,
+      .location =
+          {
+              .type = CU_MEM_LOCATION_TYPE_DEVICE,
+              .id = dev,
+          },
+  };
+
+  size_t chunk_sz = 0;
+  CHECK_DRV(cuMemGetAllocationGranularity(&chunk_sz, &prop,
+                                          CU_MEM_ALLOC_GRANULARITY_MINIMUM));
+  ASSERT(kPageSize % chunk_sz == 0,
+         "Invalid page size: %lu must be a multiple of CUDA granularity %lu\n",
+         kPageSize, chunk_sz);
+}
+
+}  // namespace vmm
+}  // namespace aphrodite
+

--- a/kernels/vmm/allocator.hpp
+++ b/kernels/vmm/allocator.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <torch/all.h>
+
+#include "constants.hpp"
+#include "ftensor.hpp"
+#include "page.hpp"
+
+namespace aphrodite {
+namespace vmm {
+
+class FTensorAllocator {
+public:
+  FTensorAllocator(const torch::Device &device, bool contiguous_layout);
+  ~FTensorAllocator();
+
+  std::vector<torch::Tensor> create_kv_tensors(size_t size, torch::Dtype dtype,
+                                               const std::string &dev_str,
+                                               int64_t num_layers);
+  bool kv_tensors_created();
+  bool map_to_kv_tensors(const std::vector<offset_t> &offsets);
+  bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets);
+
+  static void init(const std::string &dev_str, size_t page_size = 0,
+                   bool contiguous_layout = false);
+  static void shutdown();
+  static FTensorAllocator *global_allocator();
+  void destroy();
+
+private:
+  static std::string get_anon_tensor_name_();
+  std::vector<torch::Tensor>
+  create_kv_tensors_per_layer_(std::string_view prefix, size_t size,
+                               torch::Dtype dtype, const std::string &dev_str,
+                               int64_t num_layers);
+  std::vector<torch::Tensor>
+  create_kv_tensors_contiguous_(size_t size, torch::Dtype dtype,
+                                const std::string &dev_str, int64_t num_layers);
+  torch::Tensor create_ftensor_(size_t size, torch::Dtype dtype,
+                                const std::string &dev_str,
+                                std::string name = "");
+  void free_ftensor_(torch::Tensor &ftensor);
+
+  void init_cuda_();
+
+  static std::unique_ptr<FTensorAllocator> g_allocator_;
+  static std::mutex g_allocator_mutex_;
+
+  torch::Device dev_;
+
+  int64_t num_layers_;
+  bool contiguous_layout_;
+  size_t kv_tensor_size_per_layer_;
+
+  mutable std::mutex mtx_;
+  std::unordered_map<std::string, std::unique_ptr<FTensor>> ftensors_;
+  std::unique_ptr<FTensor> contiguous_kv_tensor_;
+  std::shared_ptr<Page> zero_page_;
+};
+
+}  // namespace vmm
+}  // namespace aphrodite
+

--- a/kernels/vmm/constants.hpp
+++ b/kernels/vmm/constants.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace aphrodite {
+namespace vmm {
+
+using generic_ptr_t = void *;
+using page_id_t = int64_t;
+using offset_t = page_id_t;
+
+extern size_t kPageSize;
+static constexpr size_t kStartAddr = 0x1f0'000'000'000;
+
+static constexpr page_id_t INV_PAGE_ID = -1;
+static constexpr page_id_t ZERO_PAGE_ID = INV_PAGE_ID - 1;
+
+static constexpr std::string_view k_prefix = "k_";
+static constexpr std::string_view v_prefix = "v_";
+static constexpr std::string_view kv_prefix = "kv_";
+
+}  // namespace vmm
+}  // namespace aphrodite
+

--- a/kernels/vmm/cuda_utils.hpp
+++ b/kernels/vmm/cuda_utils.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <cassert>
+#include <iostream>
+
+#define LOGE(format, ...)                                                      \
+  fprintf(stderr, "ERROR: %s:%d: " format "\n", __FILE__, __LINE__,            \
+          ##__VA_ARGS__);                                                      \
+  fflush(stderr);
+
+#define LOGW(format, ...)                                                      \
+  fprintf(stderr, "WARNING: %s:%d: " format "\n", __FILE__, __LINE__,          \
+          ##__VA_ARGS__);                                                      \
+  fflush(stderr);
+
+#define ASSERT(cond, ...)                                                      \
+  {                                                                            \
+    if (!(cond)) {                                                             \
+      LOGE(__VA_ARGS__);                                                       \
+      assert(0);                                                               \
+    }                                                                          \
+  }
+
+#define WARN(cond, ...)                                                        \
+  {                                                                            \
+    if (!(cond)) {                                                             \
+      LOGE(__VA_ARGS__);                                                       \
+    }                                                                          \
+  }
+
+#define DRV_CALL(call)                                                         \
+  {                                                                            \
+    CUresult result = (call);                                                  \
+    if (CUDA_SUCCESS != result) {                                              \
+      const char *errMsg;                                                      \
+      cuGetErrorString(result, &errMsg);                                       \
+      ASSERT(0, "Error when exec " #call " %s-%d code:%d err:%s",              \
+             __FUNCTION__, __LINE__, result, errMsg);                          \
+    }                                                                          \
+  }
+
+#define DRV_CALL_RET(call, status_val)                                         \
+  {                                                                            \
+    CUresult result = (call);                                                  \
+    if (CUDA_SUCCESS != result) {                                              \
+      const char *errMsg;                                                      \
+      cuGetErrorString(result, &errMsg);                                       \
+      WARN(0, "Error when exec " #call " %s-%d code:%d err:%s", __FUNCTION__,  \
+           __LINE__, result, errMsg);                                          \
+    }                                                                          \
+    status_val = result;                                                       \
+  }
+
+static inline void checkRtError(cudaError_t res, const char *tok,
+                                const char *file, unsigned line) {
+  if (res != cudaSuccess) {
+    std::cerr << file << ':' << line << ' ' << tok
+              << " failed in CUDA runtime (" << (unsigned)res
+              << "): " << cudaGetErrorString(res) << std::endl;
+    abort();
+  }
+}
+
+#define CHECK_RT(x) checkRtError(x, #x, __FILE__, __LINE__)
+
+static inline void checkDrvError(CUresult res, const char *tok,
+                                 const char *file, unsigned line) {
+  if (res != CUDA_SUCCESS) {
+    const char *errStr = nullptr;
+    (void)cuGetErrorString(res, &errStr);
+    std::cerr << file << ':' << line << ' ' << tok << " failed in CUDA driver ("
+              << (unsigned)res << "): " << errStr << std::endl;
+    abort();
+  }
+}
+
+#define CHECK_DRV(x) checkDrvError(x, #x, __FILE__, __LINE__)
+

--- a/kernels/vmm/ftensor.cpp
+++ b/kernels/vmm/ftensor.cpp
@@ -1,0 +1,142 @@
+#include <fcntl.h>
+#include <sys/mman.h>
+
+#include "constants.hpp"
+#include "cuda_utils.hpp"
+#include "ftensor.hpp"
+#include "page.hpp"
+
+namespace aphrodite {
+namespace vmm {
+
+static std::atomic<size_t> g_vaddr_allocated_offset = 0;
+
+static inline generic_ptr_t alloc_virtual_mem(const torch::Device &dev,
+                                              size_t size) {
+  size_t alignment_2mb = 2 * 1024 * 1024;
+  ASSERT(size % alignment_2mb == 0, "alloc size not aligned.");
+
+  generic_ptr_t vaddr;
+  size_t offset = g_vaddr_allocated_offset.fetch_add(size);
+  if (dev.is_cuda()) {
+    CHECK_DRV(cuMemAddressReserve(reinterpret_cast<CUdeviceptr *>(&vaddr), size,
+                                  alignment_2mb, kStartAddr + offset, 0ULL));
+  } else {
+    vaddr = mmap(reinterpret_cast<void *>(kStartAddr + offset), size,
+                 PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT(vaddr != MAP_FAILED, "mmap failed.");
+  }
+  return vaddr;
+}
+
+static inline std::unique_ptr<Page> make_unique_page(const torch::Device &dev,
+                                                     page_id_t page_id) {
+  if (dev.is_cuda()) {
+    return std::make_unique<GPUPage>(page_id, dev.index());
+  } else if (dev.is_cpu()) {
+    return std::make_unique<CPUPage>(page_id);
+  }
+  ASSERT(false, "Unsupported device type.");
+  return nullptr;
+}
+
+FTensor::FTensor(const std::string &name, size_t size, torch::Dtype dtype,
+                 torch::Device dev, std::shared_ptr<Page> zero_page)
+    : name_(name), vaddr_(nullptr), size_(size), dtype_(dtype), dev_(dev),
+      zero_page_(zero_page) {
+  vaddr_ = alloc_virtual_mem(dev_, size_);
+  init_with_zero_();
+
+  auto num_elems = static_cast<int64_t>(size / torch::elementSize(dtype_));
+  auto options =
+      torch::TensorOptions().dtype(dtype_).device(dev_).requires_grad(false);
+  tensor_ =
+      torch::from_blob(reinterpret_cast<void *>(vaddr_), {num_elems}, options);
+}
+
+FTensor::~FTensor() {
+  mapping_.clear();
+  zero_page_.reset();
+  if (vaddr_) {
+    CHECK_DRV(cuMemUnmap(reinterpret_cast<CUdeviceptr>(vaddr_), size_));
+    CHECK_DRV(cuMemAddressFree(reinterpret_cast<CUdeviceptr>(vaddr_), size_));
+  }
+}
+
+bool FTensor::map(offset_t offset) {
+  assert(offset % kPageSize == 0);
+
+  page_id_t page_id = offset / kPageSize;
+  if (mapping_.find(page_id) != mapping_.end()) {
+    LOGE("Page %ld is already mapped.", page_id);
+    return false;
+  }
+
+  auto vaddr = reinterpret_cast<generic_ptr_t>(
+      reinterpret_cast<uintptr_t>(vaddr_) + offset);
+  CHECK_DRV(cuMemUnmap(reinterpret_cast<CUdeviceptr>(vaddr), kPageSize));
+
+  mapping_[page_id] = make_unique_page(dev_, page_id);
+  mapping_[page_id]->map(vaddr);
+  return true;
+}
+
+bool FTensor::unmap(offset_t offset) {
+  assert(offset % kPageSize == 0);
+
+  page_id_t page_id = offset / kPageSize;
+  if (mapping_.find(page_id) == mapping_.end()) {
+    LOGE("Page %ld is not mapped.", page_id);
+    return false;
+  }
+
+  auto vaddr = reinterpret_cast<generic_ptr_t>(
+      reinterpret_cast<uintptr_t>(vaddr_) + offset);
+  CHECK_DRV(cuMemUnmap(reinterpret_cast<CUdeviceptr>(vaddr), kPageSize));
+
+  map_(zero_page_.get(), offset);
+
+  mapping_.erase(page_id);
+  return true;
+}
+
+bool FTensor::map_(Page *page, offset_t offset, bool set_access) {
+  assert(offset % kPageSize == 0);
+  assert(page);
+  auto vaddr =
+      reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(vaddr_) + offset);
+  return page->map(vaddr, set_access);
+}
+
+bool FTensor::set_access_(generic_ptr_t addr, size_t size) {
+  CUmemAccessDesc accessDesc_{
+      .location =
+          {
+              .type = CU_MEM_LOCATION_TYPE_DEVICE,
+              .id = dev_.index(),
+          },
+      .flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE,
+  };
+  CHECK_DRV(cuMemSetAccess(reinterpret_cast<CUdeviceptr>(addr), size,
+                           &accessDesc_, 1));
+  return true;
+}
+
+bool FTensor::init_with_zero_() {
+  assert(reinterpret_cast<uintptr_t>(vaddr_) % kPageSize == 0);
+  assert(size_ % kPageSize == 0);
+
+  bool succ = true;
+  for (size_t offset = 0; offset < size_; offset += kPageSize) {
+    if (!map_(zero_page_.get(), offset, true)) {
+      succ = false;
+      break;
+    }
+  }
+
+  return succ;
+}
+
+}  // namespace vmm
+}  // namespace aphrodite
+

--- a/kernels/vmm/ftensor.hpp
+++ b/kernels/vmm/ftensor.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include <torch/all.h>
+
+#include "constants.hpp"
+#include "page.hpp"
+
+namespace aphrodite {
+namespace vmm {
+
+class FTensor {
+public:
+  FTensor(const std::string &name, size_t size, torch::Dtype dtype,
+          torch::Device dev, std::shared_ptr<Page> zero_page);
+  ~FTensor();
+  bool map(offset_t offset);
+  bool unmap(offset_t offset);
+
+  inline torch::Tensor get_tensor() noexcept { return tensor_; }
+
+private:
+  bool map_(Page *page, offset_t offset, bool set_access = true);
+  bool set_access_(generic_ptr_t addr, size_t size);
+  bool init_with_zero_();
+
+  std::string name_;
+  generic_ptr_t vaddr_;
+  size_t size_;
+  torch::Dtype dtype_;
+  torch::Device dev_;
+  std::shared_ptr<Page> zero_page_;
+
+  torch::Tensor tensor_;
+  std::unordered_map<page_id_t, std::unique_ptr<Page>> mapping_;
+};
+
+}  // namespace vmm
+}  // namespace aphrodite
+

--- a/kernels/vmm/page.cpp
+++ b/kernels/vmm/page.cpp
@@ -1,0 +1,54 @@
+#include <cuda_runtime.h>
+
+#include "constants.hpp"
+#include "cuda_utils.hpp"
+#include "page.hpp"
+
+namespace aphrodite {
+namespace vmm {
+
+GPUPage::GPUPage(page_id_t page_id, int dev_idx)
+    : page_id_(page_id), dev_(dev_idx), handle_(0) {
+  CUmemAllocationProp prop = {
+      .type = CU_MEM_ALLOCATION_TYPE_PINNED,
+      .location =
+          {
+              .type = CU_MEM_LOCATION_TYPE_DEVICE,
+              .id = dev_,
+          },
+  };
+  CHECK_DRV(cuMemCreate(&handle_, kPageSize, &prop, 0));
+}
+
+GPUPage::~GPUPage() { CHECK_DRV(cuMemRelease(handle_)); }
+
+bool GPUPage::map(generic_ptr_t vaddr, bool set_access) {
+  CUmemAccessDesc accessDesc_{
+      .location =
+          {
+              .type = CU_MEM_LOCATION_TYPE_DEVICE,
+              .id = dev_,
+          },
+      .flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE,
+  };
+  CHECK_DRV(
+      cuMemMap(reinterpret_cast<CUdeviceptr>(vaddr), kPageSize, 0, handle_, 0));
+  if (set_access)
+    CHECK_DRV(cuMemSetAccess(reinterpret_cast<CUdeviceptr>(vaddr), kPageSize,
+                             &accessDesc_, 1));
+  return true;
+}
+
+CPUPage::CPUPage(page_id_t page_id)
+    : page_id_(page_id), mapped_addr_(nullptr) {}
+
+CPUPage::~CPUPage() {}
+
+bool CPUPage::map(void *vaddr, bool set_access) {
+  mapped_addr_ = vaddr;
+  return true;
+}
+
+}  // namespace vmm
+}  // namespace aphrodite
+

--- a/kernels/vmm/page.hpp
+++ b/kernels/vmm/page.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <memory>
+
+#include <cuda.h>
+#include <torch/all.h>
+
+#include "constants.hpp"
+
+namespace aphrodite {
+namespace vmm {
+
+class Page {
+public:
+  virtual ~Page() = default;
+  virtual bool map(void *vaddr, bool set_access = true) = 0;
+};
+
+class GPUPage : public Page {
+public:
+  GPUPage(page_id_t page_id, int dev_idx);
+  ~GPUPage();
+
+  bool map(void *vaddr, bool set_access = true);
+
+private:
+  page_id_t page_id_;
+  CUdevice dev_;
+  CUmemGenericAllocationHandle handle_;
+};
+
+class CPUPage : public Page {
+public:
+  CPUPage(page_id_t page_id);
+  ~CPUPage();
+
+  bool map(void *vaddr, bool set_access = true);
+
+private:
+  page_id_t page_id_;
+  generic_ptr_t mapped_addr_;
+};
+
+}  // namespace vmm
+}  // namespace aphrodite
+

--- a/kernels/vmm/torch_utils.hpp
+++ b/kernels/vmm/torch_utils.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <torch/all.h>
+
+namespace aphrodite {
+namespace vmm {
+
+static inline torch::Dtype torch_dtype_from_size(size_t dtype_size) {
+  switch (dtype_size) {
+  case 1:
+    return torch::kInt8;
+  case 2:
+    return torch::kInt16;
+  case 4:
+    return torch::kInt32;
+  case 8:
+    return torch::kInt64;
+  default:
+    throw std::runtime_error("Unsupported dtype size: " +
+                             std::to_string(dtype_size));
+  }
+}
+
+}  // namespace vmm
+}  // namespace aphrodite
+

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -52,3 +52,4 @@ python-multipart # required for multipart/form-data requests
 blobfile
 numba
 anthropic == 0.71.0
+posix_ipc >= 1.0  # required for dynamic KV cache


### PR DESCRIPTION
This enables support for dynamically allocating KV cache per request, instead of allocating the entire `gpu_memory_utilization` value all at once. To enable it, set `APHRODITE_ENABLE_DYNAMIC_KV_CACHE=1` env var, and disable prefix caching with `--no-enable-prefix-caching`.

TODO:
- [ ] ~~Investigate if we can use this with prefix caching~~