### PR TITLE
fix: DRY sampler never applies during decoding (stale token history views)

### DIFF
--- a/aphrodite/v1/worker/gpu_input_batch.py
+++ b/aphrodite/v1/worker/gpu_input_batch.py
@@ -1261,9 +1261,13 @@ class InputBatch:
         output_token_ids = cast(list[list[int]], self.req_output_token_ids) if needs_output_token_ids else []
         output_token_ids_tensor = None
         token_history_ids, token_history_lens = None, None
-        token_history_ids_cpu, token_history_lens_cpu = (
-            self._get_token_history_cpu_views(num_reqs) if not self.no_dry else (None, None)
-        )
+        # The DRY CPU kernel cannot be fed from token_ids_cpu here: cached views
+        # freeze at metadata-build width and hide every generated token, while
+        # live full-width views expose async-scheduling placeholder ids (-1) at
+        # sampling time. Passing None makes Sampler.apply_dry fall back to the
+        # persistent state, which update_dry_state keeps in sync with the real
+        # sampled ids each step.
+        token_history_ids_cpu, token_history_lens_cpu = (None, None)
 
         allowed_token_ids_mask: torch.Tensor | None = None
         if not self.no_allowed_token_ids:
@@ -1413,13 +1417,6 @@ class InputBatch:
                     dtype=torch.int64,
                 )
         return output_token_ids_cpu_tensor.to(device=self.device, non_blocking=True)
-
-    def _get_token_history_cpu_views(self, num_reqs: int) -> tuple[torch.Tensor, torch.Tensor]:
-        max_history_len = int(self.num_tokens_no_spec[:num_reqs].max()) if num_reqs else 0
-        return (
-            self.token_ids_cpu_tensor[:num_reqs, :max_history_len],
-            self.num_tokens_no_spec_cpu_tensor[:num_reqs],
-        )
 
     def _make_token_history_tensors(self, num_reqs: int) -> tuple[torch.Tensor, torch.Tensor]:
         history_lens = torch.as_tensor(


### PR DESCRIPTION
## Problem

The DRY sampler is effectively **inert during real decoding** while appearing fully configured. With any repetition-inducing prompt, `dry_multiplier=5.0` and `dry_multiplier=0.0` (same seed) produce **bit-identical outputs**.

## Root cause

`InputBatch._make_sampling_metadata()` materializes the CPU-kernel inputs as

```python
token_history_ids_cpu = self.token_ids_cpu_tensor[:num_reqs, :max_history_len]
```

with `max_history_len` computed **at metadata build time**. Sampling metadata is only rebuilt on batch-composition changes, so during steady-state decoding the view's width stays frozen at (roughly) the prompt length. Every generated token is written outside the view; `dry_scan_penalties` clamps each row's length to the tensor width and therefore rescans the **prompt-only prefix forever** (instrumentation shows per-row lens growing 36→49 while the history tensor shape stays `(1, 36)`, and the kernel returns the identical penalty set every step).

Net effect: DRY yields either no penalty at all, or a frozen prompt-derived penalty, for the entire generation.

## Why the obvious fix doesn't work

Widening the cached view to full width makes it live (row-only slices share storage), but at sampling time the tail of `token_ids_cpu` contains **async-scheduling placeholder ids (-1)**. The kernel then matches the placeholder run and emits penalties for token index `-1` (observed: `token_indexes=[-1]`, `match_lens=[65]`), i.e. it penalizes garbage.

## Fix

Stop feeding the CPU kernel and let `Sampler.apply_dry` fall through to the persistent-state python path, which is updated with the **real sampled ids** each step via `update_dry_state` and computes correct penalties.

## Verification (TP=2, Qwen3.5-family 9B, optimization-level 3)

- Repro prompt ("repeat this 10-char string 20 times"), seed fixed:
  - before: `dry=0.0` → 25 verbatim repetitions, `dry=5.0` → 25 verbatim repetitions (identical bytes)
  - after: `dry=0.0` → 25 repetitions, `dry=5.0` → **0 repetitions**
- Chat-template (thinking) requests now also diverge between `dry=0/5` (previously bit-identical end to end).
- Decode throughput unchanged within noise (69 → 66 tok/s single-stream).

Happy to adjust if you'd rather repair the CPU-kernel path instead (it would need per-step view refresh **plus** masking of the async placeholder tail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)