### PR TITLE
Migrate to new tekken crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -152,7 +152,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "thiserror-ext",
- "tiktoken-rs 0.9.1",
+ "tiktoken-rs",
  "tokenizers",
  "tokio",
  "tokio-stream",
@@ -183,7 +183,7 @@ dependencies = [
  "llm-multimodal",
  "minijinja",
  "minijinja-contrib",
- "ndarray 0.17.2",
+ "ndarray",
  "oss-harmony",
  "paste",
  "reqwest 0.13.4",
@@ -458,23 +458,14 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "serde_json",
- "tekken-rs",
+ "tekken",
  "tempfile",
  "thiserror 2.0.18",
  "thiserror-ext",
- "tiktoken-rs 0.9.1",
+ "tiktoken-rs",
  "tokenizers",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "aphrodite-tracing"
-version = "0.1.0"
-dependencies = [
- "time",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -486,6 +477,15 @@ dependencies = [
  "pythonize",
  "serde_json",
  "thiserror-ext",
+]
+
+[[package]]
+name = "aphrodite-tracing"
+version = "0.1.0"
+dependencies = [
+ "time",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2024,12 +2024,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hound"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,7 +2587,7 @@ dependencies = [
  "hf-hub",
  "image",
  "libloading",
- "ndarray 0.17.2",
+ "ndarray",
  "once_cell",
  "pkg-config",
  "rayon",
@@ -2864,21 +2858,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "ndarray"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
 ]
 
 [[package]]
@@ -3962,18 +3941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rubato"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5258099699851cfd0082aeb645feb9c084d9a5e1f1b8d5372086b989fc5e56a1"
-dependencies = [
- "num-complex",
- "num-integer",
- "num-traits",
- "realfft",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4908,25 +4875,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tekken-rs"
-version = "0.1.1"
+name = "tekken"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49623843103837f53f7ebe8cfafc19ccff28ff0e15e7c4b9f6ad21e36fbfde3a"
+checksum = "1d1481e6bbb98c7e1b04124420b6e7c367c87fc897aae340edcdeb4e91b639d2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "env_logger",
- "hound",
  "log",
- "ndarray 0.16.1",
  "regex",
- "rubato",
  "rustc-hash 1.1.0",
- "rustfft",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tiktoken-rs 0.7.0",
+ "tiktoken-rs",
 ]
 
 [[package]]
@@ -5025,21 +4988,6 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
-]
-
-[[package]]
-name = "tiktoken-rs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25563eeba904d770acf527e8b370fe9a5547bacd20ff84a0b6c3bc41288e5625"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "bstr",
- "fancy-regex 0.13.0",
- "lazy_static",
- "regex",
- "rustc-hash 1.1.0",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -101,7 +101,7 @@ strum = { version = "0.27.2", features = ["derive"] }
 subenum = "1.1.3"
 subtle = "2.6"
 task-local = "0.1.1"
-tekken = { package = "tekken-rs", version = "0.1.1", default-features = false }
+tekken = { version = "0.2.0", default-features = false }
 tempfile = "3.23.0"
 thiserror = "2.0.16"
 thiserror-ext = "0.3.0"


### PR DESCRIPTION
I am the author of [tekken-rs](https://crates.io/crates/tekken-rs) and recently renamed it to simply [tekken](https://crates.io/crates/tekken) to make it easier to import, find, and align with its library name. Since crates.io has no rename mechanism, this meant publishing a new crate; tekken-rs 0.1.2 is the final release under the old name.

Version 0.2.0 of tekken also adds:
- Support for v15 of the tokenizer
- Image tokenization support
- Audio and image dependencies gated behind feature flags

Two things to note:
- No code changes are needed: tekken-rs's library name was already tekken, so all existing use tekken::... imports will keep working
- The existing default-features = false was a no-op on 0.1.1 (it had no feature flags, so the audio dependencies were unconditional), but on 0.2.0 it takes effect: since this project only uses tekken for text tokenization, hound, rubato, rustfft, and ndarray drop out of the dependency tree, and the new image feature is never pulled in.