### PR TITLE
feat(api): expose per-replica capacity in Python and Rust frontends

### DIFF
--- a/aphrodite/entrypoints/serve/instrumentator/__init__.py
+++ b/aphrodite/entrypoints/serve/instrumentator/__init__.py
@@ -9,6 +9,10 @@ def register_instrumentator_api_routers(app: FastAPI):
 
     app.include_router(basic_router)
 
+    from .capacity import router as capacity_router
+
+    app.include_router(capacity_router)
+
     from .health import router as health_router
 
     app.include_router(health_router)

--- a/aphrodite/entrypoints/serve/instrumentator/capacity.py
+++ b/aphrodite/entrypoints/serve/instrumentator/capacity.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class EngineCapacity(BaseModel):
+    dp_rank: int
+    max_model_len: int
+    max_num_seqs: int
+    kv_cache_capacity_tokens: int | None
+    estimated_concurrency_at_max_model_len: float | None
+
+
+class CapacityResponse(BaseModel):
+    schema_version: int = 1
+    scope: str = "connected_engines"
+    engines: list[EngineCapacity]
+
+
+@router.get("/v1/capacity", response_model=CapacityResponse)
+async def capacity(request: Request) -> CapacityResponse:
+    """Return startup cache capacity for connected DP engines, not live availability.
+
+    Token capacity is a group-aware equivalent at max_model_len. Concurrency
+    estimates exclude scheduler limits and are not admission guarantees.
+    Null cache values indicate that cache capacity is unavailable or inapplicable.
+    """
+    client = getattr(request.app.state, "engine_client", None)
+    core = getattr(client, "engine_core", None)
+    reports = getattr(core, "capacity_reports", {})
+    ranks = [int.from_bytes(identity, "little") for identity in getattr(core, "core_engines", [])]
+    if not ranks or any(rank not in reports for rank in ranks):
+        raise HTTPException(status_code=503, detail="Engine capacity is not available")
+    return CapacityResponse(
+        engines=[
+            EngineCapacity(
+                dp_rank=rank,
+                max_model_len=reports[rank].max_model_len,
+                max_num_seqs=reports[rank].max_num_seqs,
+                kv_cache_capacity_tokens=reports[rank].kv_cache_size_tokens,
+                estimated_concurrency_at_max_model_len=reports[rank].kv_cache_max_concurrency,
+            )
+            for rank in sorted(ranks)
+        ]
+    )

--- a/aphrodite/v1/engine/core_client.py
+++ b/aphrodite/v1/engine/core_client.py
@@ -760,6 +760,9 @@ class MPClient(EngineCoreClient):
             return
         aphrodite_config = self.aphrodite_config
         response = msgspec.msgpack.decode(payload, type=EngineCoreReadyResponse)
+        if not hasattr(self, "capacity_reports"):
+            self.capacity_reports: dict[int, EngineCoreReadyResponse] = {}
+        self.capacity_reports[response.data_parallel_rank] = response
         aphrodite_config.model_config.max_model_len = min(
             aphrodite_config.model_config.max_model_len, response.max_model_len
         )

--- a/rust/src/server/src/routes.rs
+++ b/rust/src/server/src/routes.rs
@@ -14,6 +14,7 @@ mod pause;
 mod profile;
 pub(super) mod render;
 mod server_info;
+mod capacity;
 mod sleep;
 mod tokenize;
 mod version;
@@ -109,6 +110,7 @@ fn build_router_with_options(
         .route("/metrics", get(metrics::scrape))
         .route("/load", get(load::load))
         .route("/version", get(version::version))
+        .route("/v1/capacity", get(capacity::capacity))
         // OpenAI-compatible endpoints
         .route("/v1/models", get(openai::list_models))
         .route("/v1/completions", post(openai::completions))

--- a/rust/src/server/src/routes/capacity.rs
+++ b/rust/src/server/src/routes/capacity.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+use std::sync::Arc;
+
+use aphrodite_engine_core_client::protocol::handshake::EngineCoreReadyResponse;
+use axum::Json;
+use axum::extract::State;
+use serde_json::{Value, json};
+
+use crate::state::AppState;
+
+/// Return startup capacity for connected DP engines, not live availability.
+pub async fn capacity(State(state): State<Arc<AppState>>) -> Json<Value> {
+    Json(capacity_response(
+        state.engine_core_client().ready_responses(),
+    ))
+}
+
+fn capacity_response(mut reports: Vec<&EngineCoreReadyResponse>) -> Value {
+    reports.sort_by_key(|report| report.data_parallel_rank);
+    let engines: Vec<_> = reports
+        .iter()
+        .map(|report| {
+            json!({
+                "dp_rank": report.data_parallel_rank,
+                "max_model_len": report.max_model_len,
+                "max_num_seqs": report.max_num_seqs,
+                "kv_cache_capacity_tokens": report.kv_cache_size_tokens,
+                "estimated_concurrency_at_max_model_len": report.kv_cache_max_concurrency,
+            })
+        })
+        .collect();
+    json!({"schema_version": 1, "scope": "connected_engines", "engines": engines})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aphrodite_engine_core_client::mock_engine::default_ready_response;
+
+    #[test]
+    fn capacity_preserves_distinct_replica_values_in_rank_order() {
+        let mut first = default_ready_response();
+        first.data_parallel_rank = 1;
+        first.kv_cache_size_tokens = Some(7850);
+        first.kv_cache_max_concurrency = Some(7.85);
+        let mut second = first.clone();
+        second.data_parallel_rank = 3;
+        second.kv_cache_size_tokens = Some(9100);
+        second.kv_cache_max_concurrency = Some(9.1);
+        let result = capacity_response(vec![&second, &first]);
+        assert_eq!(result["engines"][0]["dp_rank"], 1);
+        assert_eq!(result["engines"][1]["dp_rank"], 3);
+        assert_eq!(result["engines"][0]["kv_cache_capacity_tokens"], 7850);
+        assert_eq!(result["engines"][1]["kv_cache_capacity_tokens"], 9100);
+        assert_eq!(
+            result["engines"][0]["estimated_concurrency_at_max_model_len"],
+            7.85
+        );
+        assert_eq!(
+            result["engines"][1]["estimated_concurrency_at_max_model_len"],
+            9.1
+        );
+    }
+}

--- a/rust/src/server/src/routes/tests.rs
+++ b/rust/src/server/src/routes/tests.rs
@@ -1235,6 +1235,40 @@ async fn server_load(app: &axum::Router) -> u64 {
     value["server_load"].as_u64().expect("server_load")
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn capacity_requires_auth_and_preserves_unknown_cache() {
+    let (mut app, _engine_task) = test_app_with_api_keys(vec!["secret".to_string()]).await;
+    let response = app
+        .call(Request::builder().uri("/v1/capacity").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let response = app
+        .call(
+            Request::builder()
+                .uri("/v1/capacity")
+                .header("Authorization", "Bearer secret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let ready = default_ready_response();
+    assert_eq!(value, json!({
+        "schema_version": 1, "scope": "connected_engines", "engines": [{
+            "dp_rank": ready.data_parallel_rank,
+            "max_model_len": ready.max_model_len,
+            "max_num_seqs": ready.max_num_seqs,
+            "kv_cache_capacity_tokens": null,
+            "estimated_concurrency_at_max_model_len": null,
+        }]
+    }));
+}
+
 async fn health_status(app: &axum::Router) -> (StatusCode, Bytes) {
     let response = app
         .clone()

--- a/tests/entrypoints/serve/instrumentator/test_capacity.py
+++ b/tests/entrypoints/serve/instrumentator/test_capacity.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aphrodite.entrypoints.serve.instrumentator.capacity import router
+from aphrodite.entrypoints.serve.middleware.authenticate import AuthenticationMiddleware
+
+
+def test_capacity_auth_replica_scope_and_unavailable():
+    app = FastAPI()
+    app.include_router(router)
+    app.add_middleware(AuthenticationMiddleware, tokens=["secret"])
+    core = SimpleNamespace(
+        core_engines=[rank.to_bytes(2, "little") for rank in [3, 1]],
+        capacity_reports={
+            rank: SimpleNamespace(
+                max_model_len=1000,
+                max_num_seqs=32,
+                kv_cache_size_tokens=tokens,
+                kv_cache_max_concurrency=concurrency,
+            )
+            for rank, tokens, concurrency in [(1, 7850, 7.85), (3, None, None), (4, 9000, 9.0)]
+        },
+    )
+    app.state.engine_client = SimpleNamespace(engine_core=core)
+    with TestClient(app) as client:
+        assert client.get("/v1/capacity").status_code == 401
+        response = client.get("/v1/capacity", headers={"Authorization": "Bearer secret"})
+        assert response.status_code == 200
+        assert response.json() == {
+            "schema_version": 1,
+            "scope": "connected_engines",
+            "engines": [
+                {
+                    "dp_rank": rank,
+                    "max_model_len": 1000,
+                    "max_num_seqs": 32,
+                    "kv_cache_capacity_tokens": tokens,
+                    "estimated_concurrency_at_max_model_len": concurrency,
+                }
+                for rank, tokens, concurrency in [(1, 7850, 7.85), (3, None, None)]
+            ],
+        }
+        core.capacity_reports = {}
+        assert client.get("/v1/capacity", headers={"Authorization": "Bearer secret"}).status_code == 503

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -327,6 +327,15 @@ def test_apply_ready_response_syncs_block_size():
     )
     client._apply_ready_response(payload)
     assert client.aphrodite_config.cache_config.block_size == 1056
+    import dataclasses
+
+    first = client.capacity_reports[0]
+    second = dataclasses.replace(first, data_parallel_rank=1, kv_cache_size_tokens=1234)
+    client._apply_ready_response(msgspec.msgpack.encode(second))
+    assert client.capacity_reports == {0: first, 1: second}
+    updated = dataclasses.replace(second, kv_cache_size_tokens=5678)
+    client._apply_ready_response(msgspec.msgpack.encode(updated))
+    assert client.capacity_reports == {0: first, 1: updated}
 
 
 def test_apply_ready_response_syncs_mamba_block_size():


### PR DESCRIPTION
e.g., `GET` to `/v1/capacity` will now produce:

```json
{
  "schema_version": 1,
  "scope": "connected_engines",
  "engines": [
    {
      "dp_rank": 0,
      "max_model_len": 262144,
      "max_num_seqs": 256,
      "kv_cache_capacity_tokens": 6775455,
      "estimated_concurrency_at_max_model_len": 25.846311475409838
    }
  ]
}
```