### PR TITLE
fix(build): resolve Rust package version without Git metadata

### DIFF
--- a/.github/scripts/build_nightly_commits.sh
+++ b/.github/scripts/build_nightly_commits.sh
@@ -25,6 +25,15 @@ encode_path() {
   printf '%s' "${1//+/%2B}"
 }
 
+build_with_current_rust_helper() (
+  local commit="$1"
+  local version="$2"
+  # Packaging fixes must also apply to commits awaiting their first wheel.
+  trap 'git restore --source="$commit" -- tools/build_rust.py' EXIT
+  git show "${target_commit}:tools/build_rust.py" > tools/build_rust.py
+  APHRODITE_VERSION_OVERRIDE="$version" ./docker/export_wheels.sh
+)
+
 upload_wheel() {
   local wheel="$1"
   local remote="$2"
@@ -153,7 +162,7 @@ for commit in "${commits[@]}"; do
     version="${major}.${minor}.$((patch + 1)).dev${timestamp}+cu130.g${short_commit}"
     echo "Building ${version} from ${commit}"
 
-    APHRODITE_VERSION_OVERRIDE="$version" ./docker/export_wheels.sh
+    build_with_current_rust_helper "$commit" "$version"
     wheel="$(find wheels/main -maxdepth 1 -type f -name '*.whl' -print -quit)"
     if [[ -z "$wheel" ]]; then
       echo "::error::The build did not export a wheel for ${commit}"

--- a/.github/scripts/reconcile_platform_wheels.sh
+++ b/.github/scripts/reconcile_platform_wheels.sh
@@ -33,6 +33,15 @@ encode_path() {
   printf '%s' "${1//+/%2B}"
 }
 
+build_with_current_rust_helper() (
+  local commit="$1"
+  local version="$2"
+  # Packaging fixes must also apply to commits awaiting their first wheel.
+  trap 'git restore --source="$commit" -- tools/build_rust.py' EXIT
+  git show "${target_commit}:tools/build_rust.py" > tools/build_rust.py
+  APHRODITE_VERSION_OVERRIDE="$version" "$PLATFORM_BUILD_SCRIPT" "$output_dir"
+)
+
 upload_wheel() {
   local wheel="$1"
   local remote="$2"
@@ -189,8 +198,7 @@ for commit in "${commits[@]}"; do
     version="${major}.${minor}.$((patch + 1)).dev${timestamp}+${PLATFORM_VERSION_LOCAL}.g${short_commit}"
     echo "Building ${version} from ${commit}"
 
-    APHRODITE_VERSION_OVERRIDE="$version" \
-      "$PLATFORM_BUILD_SCRIPT" "$output_dir"
+    build_with_current_rust_helper "$commit" "$version"
     wheel="$(find "$output_dir" -maxdepth 1 -type f -name '*.whl' -print -quit)"
     if [[ -z "$wheel" ]]; then
       echo "::error::The build did not export a wheel for ${commit}"

--- a/tests/scripts/test_nightly_rust_helper.py
+++ b/tests/scripts/test_nightly_rust_helper.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("script", ["build_nightly_commits.sh", "reconcile_platform_wheels.sh"])
+@pytest.mark.parametrize("build_status", [0, 1])
+def test_backlog_uses_current_helper_and_restores_checkout(tmp_path, script, build_status):
+    root = Path(__file__).resolve().parents[2]
+    source = (root / ".github/scripts" / script).read_text()
+    function = (
+        "build_with_current_rust_helper() ("
+        + source.split("build_with_current_rust_helper() (", 1)[1].split("\n)", 1)[0]
+        + "\n)"
+    )
+
+    def git(*args):
+        return subprocess.check_output(["git", *args], cwd=tmp_path, text=True).strip()
+
+    git("init", "-q")
+    git("config", "user.name", "Test")
+    git("config", "user.email", "test@example.com")
+    (tmp_path / "tools").mkdir()
+    helper = tmp_path / "tools/build_rust.py"
+    helper.write_text("old helper\n")
+    git("add", ".")
+    git("-c", "core.hooksPath=/dev/null", "commit", "-qm", "old")
+    old = git("rev-parse", "HEAD")
+    helper.write_text("new helper\n")
+    git("add", ".")
+    git("-c", "core.hooksPath=/dev/null", "commit", "-qm", "new")
+    new = git("rev-parse", "HEAD")
+    git("checkout", "--detach", old)
+    (tmp_path / "docker").mkdir()
+    build = tmp_path / "docker/export_wheels.sh"
+    build.write_text(
+        "#!/bin/bash\nset -eu\n"
+        'test "$(<tools/build_rust.py)" = "new helper"\n'
+        'test "$APHRODITE_VERSION_OVERRIDE" = "0.24.0"\n'
+        f"exit {build_status}\n"
+    )
+    build.chmod(0o755)
+    result = subprocess.run(
+        [
+            "bash",
+            "-eu",
+            "-c",
+            function + '\ntarget_commit="$1"\n'
+            "PLATFORM_BUILD_SCRIPT=./docker/export_wheels.sh\noutput_dir=wheels\n"
+            'build_with_current_rust_helper "$2" 0.24.0',
+            "test",
+            new,
+            old,
+        ],
+        cwd=tmp_path,
+    )
+    assert result.returncode == build_status
+    assert helper.read_text() == "old helper\n"
+    assert git("diff", "--name-only") == ""

--- a/tests/tools/test_build_rust.py
+++ b/tests/tools/test_build_rust.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("version", [None, "0.24.0.dev1"])
+def test_rust_build_without_git_metadata(tmp_path, version):
+    """The cached Docker stage inherits pyproject.toml but has no .git."""
+    root = Path(__file__).resolve().parents[2]
+    (tmp_path / "tools").mkdir()
+    shutil.copy2(root / "tools/build_rust.py", tmp_path / "tools/build_rust.py")
+    shutil.copy2(root / "pyproject.toml", tmp_path / "pyproject.toml")
+    env = os.environ.copy()
+    for key in list(env):
+        if key.startswith("SETUPTOOLS_SCM_PRETEND_VERSION") or key == "APHRODITE_RS_BUILD_VERSION":
+            env.pop(key)
+    if version:
+        env["APHRODITE_RS_BUILD_VERSION"] = version
+    # Command help runs the actual setuptools initialization, without Cargo.
+    result = subprocess.run(
+        [sys.executable, "tools/build_rust.py", "--help"],
+        cwd=tmp_path,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "build_rust" in result.stdout

--- a/tools/build_rust.py
+++ b/tools/build_rust.py
@@ -69,6 +69,10 @@ def build_binary(build_rust_args: list[str]) -> None:
     (ROOT_DIR / "aphrodite").mkdir(exist_ok=True)
     setup(
         name="aphrodite-rust-frontend-build",
+        # Docker's cached Rust stage has pyproject.toml but no Git metadata.
+        # Give this build-only distribution a version so setuptools-scm does
+        # not try to infer one again during setup().
+        version=os.getenv(APHRODITE_RS_BUILD_VERSION) or "0.0.0",
         packages=[],
         rust_extensions=rust_extensions(optional=False),
         script_args=["build_rust", "--quiet", "--inplace", *build_rust_args],


### PR DESCRIPTION
Give the standalone Rust build distribution an explicit version so setuptools-scm can initialize in cached Docker stages without Git metadata. Apply the current Rust packaging helper when reconciling older CUDA and platform commits, restoring the original file after each build. Validation: six regression tests, touched-file pre-commit, and ShellCheck passed.