### PR TITLE
fix(ci): isolate PR cleanup from main wheel builds

### DIFF
--- a/.github/workflows/platform-wheel.yml
+++ b/.github/workflows/platform-wheel.yml
@@ -35,7 +35,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: platform-wheels-${{ github.event.issue.number || inputs.pr_number || github.ref }}
+  group: platform-wheels-${{ github.event.issue.number || github.event.pull_request.number || inputs.pr_number || github.ref }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Include the closed PR number in the wheel workflow concurrency key. PR cleanup can otherwise replace a pending main nightly run when a merge produces both events. Validation: actionlint and touched-file pre-commit passed.