### PR TITLE
fix(dry): refresh native sampler token history

### DIFF
--- a/aphrodite/v1/worker/gpu_input_batch.py
+++ b/aphrodite/v1/worker/gpu_input_batch.py
@@ -1440,10 +1440,27 @@ class InputBatch:
         return output_token_ids_cpu_tensor.to(device=self.device, non_blocking=True)
 
     def _get_token_history_cpu_views(self, num_reqs: int) -> tuple[torch.Tensor, torch.Tensor]:
-        max_history_len = int(self.num_tokens_no_spec[:num_reqs].max()) if num_reqs else 0
+        # Async speculative decoding can reserve more output slots than were
+        # accepted. Use resolved output lengths, not optimistic scheduler counts.
+        output_token_ids = cast(list[list[int]], self.req_output_token_ids[:num_reqs])
+        history_lens = self.num_prompt_tokens[:num_reqs] + np.fromiter(
+            (len(tokens) for tokens in output_token_ids),
+            dtype=np.int32,
+            count=num_reqs,
+        )
+        max_history_len = int(history_lens.max()) if num_reqs else 0
         return (
             self.token_ids_cpu_tensor[:num_reqs, :max_history_len],
-            self.num_tokens_no_spec_cpu_tensor[:num_reqs],
+            torch.from_numpy(history_lens),
+        )
+
+    def refresh_dry_token_history(self) -> None:
+        """Refresh the native DRY scanner's views after resolving sampled IDs."""
+        if self.no_dry:
+            return
+        metadata = self.sampling_metadata
+        metadata.token_history_ids_cpu, metadata.token_history_lens_cpu = self._get_token_history_cpu_views(
+            self.num_reqs
         )
 
     def _make_token_history_tensors(self, num_reqs: int) -> tuple[torch.Tensor, torch.Tensor]:
@@ -1580,6 +1597,11 @@ class InputBatch:
             del new_ids[num_to_replace:]
             req_output_token_ids[first_placeholder:] = new_ids
             # ^ Implicitly resizes to (first_placeholder + num_to_replace)
+            if req_id in self.dry_reqs:
+                # The native DRY scanner reads this buffer, not the Python list.
+                # Copy only the resolved suffix, leaving scheduler counts intact.
+                start = self.num_prompt_tokens[index] + first_placeholder
+                self.token_ids_cpu[index, start : start + num_to_replace] = new_ids
 
     def update_async_spec_token_ids(self, draft_token_ids: list[list[int]]) -> None:
         """

--- a/aphrodite/v1/worker/gpu_model_runner.py
+++ b/aphrodite/v1/worker/gpu_model_runner.py
@@ -3463,6 +3463,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin, ECConnec
         # Update output token ids with tokens sampled in last step
         # if async scheduling and required by current sampling params.
         self.input_batch.update_async_output_token_ids()
+        self.input_batch.refresh_dry_token_history()
         if spec_decode_metadata is None:
             return self.sampler(
                 logits=logits,

--- a/tests/v1/worker/test_dry_token_history.py
+++ b/tests/v1/worker/test_dry_token_history.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from aphrodite.platforms import current_platform
+from aphrodite.sampling_params import SamplingParams
+from aphrodite.v1.sample.ops import SamplingOps
+from aphrodite.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
+from aphrodite.v1.worker.gpu_model_runner import GPUModelRunner
+
+
+def make_batch(prompts, outputs):
+    batch = object.__new__(InputBatch)
+    batch._req_ids = [f"req{i}" for i in range(len(prompts))]
+    batch.req_id_to_index = {req_id: i for i, req_id in enumerate(batch._req_ids)}
+    batch.dry_reqs = set(batch._req_ids)
+    batch.req_output_token_ids = outputs
+    batch.num_prompt_tokens = np.array(list(map(len, prompts)), dtype=np.int32)
+    batch.token_ids_cpu_tensor = torch.full((len(prompts), 64), -1, dtype=torch.int32)
+    batch.token_ids_cpu = batch.token_ids_cpu_tensor.numpy()
+    for row, (prompt, output) in enumerate(zip(prompts, outputs)):
+        batch.token_ids_cpu[row, : len(prompt) + len(output)] = prompt + output
+    batch.num_tokens_no_spec = batch.num_prompt_tokens + np.array(list(map(len, outputs)), dtype=np.int32)
+    batch.sampled_token_ids_cpu = None
+    batch.prev_req_id_to_index = None
+    batch.async_copy_ready_event = Mock()
+    metadata = SimpleNamespace(
+        output_token_ids=outputs,
+        prompt_token_ids=torch.tensor(prompts),
+        persistent_data={},
+        token_history_ids_cpu=None,
+        token_history_lens_cpu=None,
+    )
+    for name, value in dict(
+        multiplier=5.0,
+        base=1.75,
+        allowed_length=1,
+        ranges=0,
+        max_ngram=12,
+        max_occurrences=8,
+        early_exit_match_len=8,
+    ).items():
+        tensor = torch.full((len(prompts),), value, dtype=torch.float32 if isinstance(value, float) else torch.int32)
+        setattr(metadata, "dry_" + name, tensor)
+        setattr(metadata, "dry_" + name + "_cpu", tensor)
+    metadata.dry_sequence_breaker_ids = torch.empty((len(prompts), 0), dtype=torch.long)
+    metadata.dry_sequence_breaker_ids_cpu = metadata.dry_sequence_breaker_ids
+    batch.sampling_metadata = metadata
+    return batch
+
+
+def assert_native_matches_reference(batch):
+    current_platform.import_kernels()
+    if not hasattr(torch.ops._C, "dry_scan_penalties"):
+        pytest.skip("Native DRY scanner is not built on this platform")
+    metadata = batch.sampling_metadata
+    logits = torch.zeros((batch.num_reqs, 16))
+    # Fail if the native path accidentally falls back to Python.
+    with patch("aphrodite.v1.sample.ops._compute_dry_penalties", side_effect=AssertionError("Python fallback")):
+        native = SamplingOps().apply_dry(logits.clone(), metadata)
+    with patch.object(metadata, "token_history_ids_cpu", None):
+        reference = SamplingOps().apply_dry(logits.clone(), metadata)
+    torch.testing.assert_close(native, reference, rtol=0, atol=0)
+    return native
+
+
+def test_dry_history_grows_without_batch_changes():
+    batch = make_batch([[1, 2]], [[]])
+    batch.refresh_dry_token_history()
+    metadata = batch.sampling_metadata
+    assert metadata.token_history_ids_cpu.shape == (1, 2)
+
+    for token in [1, 2, 1, 2]:
+        end = batch.num_tokens_no_spec[0]
+        batch.token_ids_cpu[0, end] = token
+        batch.num_tokens_no_spec[0] += 1
+        batch.req_output_token_ids[0].append(token)
+        batch.refresh_dry_token_history()
+        assert batch.sampling_metadata is metadata
+        assert metadata.token_history_ids_cpu.shape[1] == end + 1
+        result = assert_native_matches_reference(batch)
+    assert result[0, 1] < 0
+
+
+@pytest.mark.parametrize("accepted", [0, 1, 2, 3])
+def test_dry_async_reordering_and_partial_acceptance(accepted):
+    batch = make_batch([[1, 2], [3, 4]], [[-1, -1, -1], [-1, -1, -1]])
+    batch.prev_req_id_to_index = {"req0": 1, "req1": 0}
+    batch.sampled_token_ids_cpu = torch.tensor(
+        [[3, 4, 3][:accepted] + [-1] * (3 - accepted), [1, 2, 1][:accepted] + [-1] * (3 - accepted)]
+    )
+    optimistic_counts = batch.num_tokens_no_spec.copy()
+    batch.update_async_output_token_ids()
+    batch.refresh_dry_token_history()
+    batch.async_copy_ready_event.synchronize.assert_called_once()
+    metadata = batch.sampling_metadata
+    assert metadata.token_history_lens_cpu.tolist() == [2 + accepted] * 2
+    assert metadata.token_history_ids_cpu.tolist() == [
+        [1, 2] + [1, 2, 1][:accepted],
+        [3, 4] + [3, 4, 3][:accepted],
+    ]
+    np.testing.assert_array_equal(batch.num_tokens_no_spec, optimistic_counts)
+    assert_native_matches_reference(batch)
+
+
+def test_dry_async_discarded_outputs_limit_copy():
+    batch = make_batch([[1, 2]], [[1, -1]])
+    batch.prev_req_id_to_index = {"req0": 0}
+    batch.sampled_token_ids_cpu = torch.tensor([[2, 9, 9]])
+    batch.update_async_output_token_ids()
+    batch.refresh_dry_token_history()
+    assert batch.sampling_metadata.token_history_ids_cpu.tolist() == [[1, 2, 1, 2]]
+    assert batch.token_ids_cpu[0, 4] == -1
+    assert assert_native_matches_reference(batch)[0, 1] == -8.75
+
+
+def test_dry_refresh_skipped_when_disabled():
+    batch = make_batch([[1, 2]], [[]])
+    batch.dry_reqs.clear()
+    with patch.object(batch, "_get_token_history_cpu_views", side_effect=AssertionError("Unnecessary history work")):
+        batch.refresh_dry_token_history()
+
+
+def test_dry_history_survives_compaction_and_slot_reuse():
+    batch = InputBatch(
+        max_num_reqs=3,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        device=torch.device("cpu"),
+        vocab_size=16,
+        block_sizes=[16],
+        kernel_block_sizes=[16],
+        max_num_blocks_per_req=[4],
+    )
+
+    def add(req_id, pair):
+        batch.add_request(
+            CachedRequestState(
+                req_id=req_id,
+                prompt_token_ids=pair,
+                mm_features=[],
+                sampling_params=SamplingParams(dry_multiplier=5, dry_allowed_length=1, dry_sequence_breaker_ids=[]),
+                pooling_params=None,
+                block_ids=([],),
+                generator=None,
+                num_computed_tokens=2,
+                output_token_ids=pair.copy(),
+            )
+        )
+
+    add("a", [1, 2])
+    add("b", [3, 4])
+    add("c", [5, 6])
+    batch.refresh_metadata()
+    batch.remove_request("b")
+    batch.condense()
+    batch.refresh_metadata()
+    add("d", [7, 8])
+    batch.refresh_metadata()
+    batch.refresh_dry_token_history()
+    assert batch.req_ids == ["a", "c", "d"]
+    assert batch.sampling_metadata.token_history_ids_cpu.tolist() == [[1, 2, 1, 2], [5, 6, 5, 6], [7, 8, 7, 8]]
+    assert_native_matches_reference(batch)
+
+
+@pytest.mark.parametrize("speculative", [False, True])
+def test_runner_refreshes_dry_after_resolving_async_tokens(speculative):
+    batch = make_batch([[1, 2]], [[1, -1]])
+    batch.prev_req_id_to_index = {"req0": 0}
+    batch.sampled_token_ids_cpu = torch.tensor([[2]])
+    runner = object.__new__(GPUModelRunner)
+    runner.input_batch = batch
+    runner.use_async_scheduling = True
+    runner._draft_token_req_ids = None
+    runner._get_spec_decode_draft_probs = Mock(return_value=None)
+
+    def sample(*args, **kwargs):
+        assert batch.sampling_metadata.token_history_ids_cpu.tolist() == [[1, 2, 1, 2]]
+        return "sampled"
+
+    runner.sampler = Mock(side_effect=sample)
+    runner.rejection_sampler = Mock(side_effect=sample)
+    assert runner._sample(torch.zeros((1, 16)), Mock() if speculative else None) == "sampled"

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -853,6 +853,7 @@ def test_sample_passes_reordered_draft_probs_to_rejection_sampler():
     runner.input_batch = SimpleNamespace(
         sampling_metadata=Mock(spec=SamplingMetadata),
         update_async_output_token_ids=Mock(),
+        refresh_dry_token_history=Mock(),
         req_ids=["req_a", "req_b", "req_c"],
     )
     runner.rejection_sampler = Mock(return_value="sampler_output")


### PR DESCRIPTION
Replaces #1720 by fixing the C++ path instead of using the python fallback.