### PR TITLE
feat: add per-request phrase suppression with rollback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,18 @@ else()
 endif()
 
 #
+# Pure CPU matcher, independent of Torch and CUDA ABIs.
+#
+define_extension_target(
+  _phrase_matcher
+  DESTINATION aphrodite
+  LANGUAGE CXX
+  SOURCES csrc/phrase_matcher.cpp
+  NO_TORCH
+  USE_SABI 3.8
+  WITH_SOABI)
+
+#
 # spinloop extension (pure CXX; must stay above the non-CUDA device branch so
 # CPU builds define the target before the early return)
 # This extension requires SABI 3.11 since it relies on Py_buffer support. Loading

--- a/aphrodite/_phrase_matcher.pyi
+++ b/aphrodite/_phrase_matcher.pyi
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Sequence
+
+def compile(patterns: Sequence[bytes], /) -> object: ...
+def scan(pattern: object, state: int, data: bytes, /) -> tuple[int, int | None, int]: ...

--- a/aphrodite/model_executor/models/qwen3_5_mtp.py
+++ b/aphrodite/model_executor/models/qwen3_5_mtp.py
@@ -145,19 +145,15 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         inputs_embeds: torch.Tensor | None = None,
         spec_step_idx: int = 0,
     ) -> torch.Tensor:
-        if get_pp_group().is_first_rank:
-            if inputs_embeds is None:
-                inputs_embeds = self.embed_input_ids(input_ids)
-            assert hidden_states.shape[-1] == inputs_embeds.shape[-1]
-            inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)
-            hidden_states = self.pre_fc_norm_hidden(hidden_states)
-            hidden_states = torch.cat([inputs_embeds, hidden_states], dim=-1)
-            hidden_states = self.fc(hidden_states)
-            residual = None
-        else:
-            assert intermediate_tensors is not None
-            hidden_states = intermediate_tensors["hidden_states"]
-            residual = intermediate_tensors["residual"]
+        # The full draft head runs on the target's last pipeline stage.
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_input_ids(input_ids)
+        assert hidden_states.shape[-1] == inputs_embeds.shape[-1]
+        inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)
+        hidden_states = self.pre_fc_norm_hidden(hidden_states)
+        hidden_states = torch.cat([inputs_embeds, hidden_states], dim=-1)
+        hidden_states = self.fc(hidden_states)
+        residual = None
 
         current_step_idx = spec_step_idx % self.num_mtp_layers
         mtp_layer = self.layers[current_step_idx]
@@ -170,9 +166,6 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             hidden_states=hidden_states,
             residual=residual,
         )
-
-        if not get_pp_group().is_last_rank:
-            return IntermediateTensors({"hidden_states": hidden_states, "residual": residual})
 
         hidden_states, _ = self.norm(hidden_states, residual)
         if mtp_layer.use_attn_reduce_scatter_for_moe:

--- a/aphrodite/v1/engine/input_processor.py
+++ b/aphrodite/v1/engine/input_processor.py
@@ -91,6 +91,7 @@ class InputProcessor:
                 PhraseRetryProcessor.validate_params(params)
                 if not issubclass(self.aphrodite_config.scheduler_config.get_scheduler_cls(), PhraseScheduler):
                     raise ValueError("banned_strings requires PhraseScheduler")
+                PhraseRetryProcessor.validate_runtime(self.aphrodite_config, self.tokenizer)
             supported_generation_tasks = [task for task in supported_tasks if task in GENERATION_TASKS]
             if not supported_generation_tasks:
                 raise APHRODITEValidationError("This model does not support generation")
@@ -382,6 +383,13 @@ class InputProcessor:
                         mm_hash=base_mm_hash,
                     )
                 )
+
+        if sampling_params is not None and "banned_strings" in (sampling_params.extra_args or {}):
+            from aphrodite.v1.phrase_guard.processor import PhraseRetryProcessor
+
+            PhraseRetryProcessor.validate_input(
+                resumable, bool(mm_features) or encoder_input is not None, prompt_embeds
+            )
 
         return EngineCoreRequest(
             request_id=request_id,

--- a/aphrodite/v1/engine/input_processor.py
+++ b/aphrodite/v1/engine/input_processor.py
@@ -84,6 +84,13 @@ class InputProcessor:
     ) -> None:
         """Raise `ValueError` if SamplingParams or PoolingParams is not valid."""
         if isinstance(params, SamplingParams):
+            if "banned_strings" in (params.extra_args or {}) or "_sonar_phrase_retry" in (params.extra_args or {}):
+                from aphrodite.v1.phrase_guard.processor import PhraseRetryProcessor
+                from aphrodite.v1.phrase_guard.scheduler import PhraseScheduler
+
+                PhraseRetryProcessor.validate_params(params)
+                if not issubclass(self.aphrodite_config.scheduler_config.get_scheduler_cls(), PhraseScheduler):
+                    raise ValueError("banned_strings requires PhraseScheduler")
             supported_generation_tasks = [task for task in supported_tasks if task in GENERATION_TASKS]
             if not supported_generation_tasks:
                 raise APHRODITEValidationError("This model does not support generation")

--- a/aphrodite/v1/phrase_guard/__init__.py
+++ b/aphrodite/v1/phrase_guard/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Opt-in experiments for transactional phrase suppression."""

--- a/aphrodite/v1/phrase_guard/logprobs.py
+++ b/aphrodite/v1/phrase_guard/logprobs.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections import deque
+
+import numpy as np
+
+from aphrodite.v1.outputs import LogprobsLists
+
+
+def join_logprobs(rows: list[LogprobsLists]) -> LogprobsLists | None:
+    if not rows:
+        return None
+    if len(rows) == 1:
+        return rows[0]
+    return LogprobsLists(*(np.concatenate([row[i] for row in rows]) for i in range(3)))
+
+
+class PendingLogprobs:
+    def __init__(self):
+        self.rows: deque[LogprobsLists] = deque()
+
+    def append(self, packet: LogprobsLists, index: int):
+        # A held token must not retain another request's whole batch allocation.
+        self.rows.append(LogprobsLists(*(array[index : index + 1].copy() for array in packet[:3])))
+
+    def take(self, count: int) -> list[LogprobsLists]:
+        return [self.rows.popleft() for _ in range(count)]
+
+    def clear(self):
+        self.rows.clear()

--- a/aphrodite/v1/phrase_guard/matcher.py
+++ b/aphrodite/v1/phrase_guard/matcher.py
@@ -2,7 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from dataclasses import dataclass
-from functools import lru_cache
+from threading import RLock
+
+from cachetools import LRUCache, cached
 
 import aphrodite._phrase_matcher as _phrase_matcher
 
@@ -10,6 +12,7 @@ MAX_PHRASES = 2048
 MAX_PHRASE_CHARS = 256
 MAX_ZERO_WIDTH_TOKENS = 256
 MAX_RETRIES = 128
+_pattern_cache: LRUCache[tuple, tuple[object, int]] = LRUCache(maxsize=65536, getsizeof=lambda entry: entry[1])
 
 
 def validate_phrases(value: object) -> tuple[str, ...]:
@@ -23,11 +26,16 @@ def validate_phrases(value: object) -> tuple[str, ...]:
     return tuple(dict.fromkeys(value))
 
 
-@lru_cache(maxsize=32)
+@cached(_pattern_cache, lock=RLock())
+def _compile_phrases(phrases: tuple[str, ...], case_sensitive: bool) -> tuple[object, int]:
+    encoded = tuple((phrase if case_sensitive else phrase.casefold()).encode("utf-8") for phrase in phrases)
+    # Each encoded byte adds at most one trie node. Include cache-entry overhead;
+    # entries larger than the cache budget are compiled without being retained.
+    return _phrase_matcher.compile(encoded), sum(map(len, encoded)) + 64
+
+
 def compile_phrases(phrases: tuple[str, ...], case_sensitive: bool):
-    return _phrase_matcher.compile(
-        tuple((phrase if case_sensitive else phrase.casefold()).encode("utf-8") for phrase in phrases)
-    )
+    return _compile_phrases(phrases, case_sensitive)[0]
 
 
 @dataclass(frozen=True)

--- a/aphrodite/v1/phrase_guard/matcher.py
+++ b/aphrodite/v1/phrase_guard/matcher.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+from functools import lru_cache
+
+from aphrodite import _phrase_matcher
+
+MAX_PHRASES = 2048
+MAX_PHRASE_CHARS = 256
+MAX_PENDING_TOKENS = 256
+MAX_RETRIES = 128
+
+
+def validate_phrases(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value or len(value) > MAX_PHRASES:
+        raise ValueError(f"banned_strings must be a nonempty list of at most {MAX_PHRASES} strings")
+    for phrase in value:
+        if not isinstance(phrase, str) or not 0 < len(phrase) <= MAX_PHRASE_CHARS:
+            raise ValueError(f"Each banned string must contain 1..{MAX_PHRASE_CHARS} characters")
+    if sum(len(phrase.casefold().encode("utf-8")) for phrase in value) > 262144:
+        raise ValueError("banned_strings exceeds the 256 KiB phrase budget")
+    return tuple(dict.fromkeys(value))
+
+
+@lru_cache(maxsize=32)
+def compile_phrases(phrases: tuple[str, ...], case_sensitive: bool):
+    return _phrase_matcher.compile(
+        tuple((phrase if case_sensitive else phrase.casefold()).encode("utf-8") for phrase in phrases)
+    )
+
+
+@dataclass(frozen=True)
+class Decision:
+    ready: list[int]
+    rewind_to: int | None = None
+    blocked_token: int | None = None
+
+
+class PendingText:
+    """Token-aligned output journal. Only ``ready`` tokens may leave the engine."""
+
+    def __init__(self, phrases: tuple[str, ...], case_sensitive: bool = False):
+        self.pattern = compile_phrases(phrases, case_sensitive)
+        self.case_sensitive = case_sensitive
+        self.state = 0
+        self.tokens: list[int] = []
+        self.ends: list[int] = []
+        self.states: list[int] = []
+        self.published_state = 0
+        self.num_bytes = 0
+        self.published = 0
+
+    def _token_at(self, byte_offset: int) -> int:
+        # Include zero-width tokens which contributed to a later decoded
+        # character. A UTF-8 character can span several byte-fallback tokens.
+        start = 0
+        for i, end in enumerate(self.ends):
+            if end > byte_offset:
+                return start
+            if end > (self.ends[i - 1] if i else 0):
+                start = i + 1
+        return start
+
+    def _release(self, count: int) -> list[int]:
+        if not count:
+            return []
+        ready = self.tokens[:count]
+        released_bytes = self.ends[count - 1]
+        self.tokens = self.tokens[count:]
+        self.ends = [end - released_bytes for end in self.ends[count:]]
+        self.published_state = self.states[count - 1]
+        self.states = self.states[count:]
+        self.num_bytes -= released_bytes
+        self.published += count
+        return ready
+
+    def feed(self, token: int, text: str) -> Decision:
+        self.tokens.append(token)
+        data = (text if self.case_sensitive else text.casefold()).encode("utf-8")
+        offset = self.num_bytes
+        self.num_bytes += len(data)
+        self.ends.append(self.num_bytes)
+        if len(self.tokens) > MAX_PENDING_TOKENS:
+            raise ValueError("banned_strings pending-token limit exceeded")
+        self.state, match, suffix = _phrase_matcher.scan(self.pattern, self.state, data)
+        self.states.append(self.state)
+        keep_from = self.num_bytes - suffix
+        if match is not None:
+            start = min(offset + match, keep_from)
+            boundary = self._token_at(start)
+            ready = self._release(boundary)
+            blocked = self.tokens[0]
+            self.tokens.clear()
+            self.ends.clear()
+            self.states.clear()
+            self.num_bytes = 0
+            # Whole-token rollback can reactivate a previously released prefix.
+            self.state = self.published_state
+            return Decision(ready, self.published, blocked)
+        # Retain zero-width tokens until their decode is resolved.
+        return Decision(self._release(self._token_at(keep_from)))
+
+    def finish(self) -> list[int]:
+        """Release an incomplete prefix at EOS, after checking the final token."""
+        return self._release(len(self.tokens))

--- a/aphrodite/v1/phrase_guard/matcher.py
+++ b/aphrodite/v1/phrase_guard/matcher.py
@@ -18,7 +18,7 @@ def validate_phrases(value: object) -> tuple[str, ...]:
     for phrase in value:
         if not isinstance(phrase, str) or not 0 < len(phrase) <= MAX_PHRASE_CHARS:
             raise ValueError(f"Each banned string must contain 1..{MAX_PHRASE_CHARS} characters")
-    if sum(len(phrase.casefold().encode("utf-8")) for phrase in value) > 262144:
+    if sum(max(len(phrase.encode("utf-8")), len(phrase.casefold().encode("utf-8"))) for phrase in value) > 262144:
         raise ValueError("banned_strings exceeds the 256 KiB phrase budget")
     return tuple(dict.fromkeys(value))
 

--- a/aphrodite/v1/phrase_guard/matcher.py
+++ b/aphrodite/v1/phrase_guard/matcher.py
@@ -8,7 +8,7 @@ import aphrodite._phrase_matcher as _phrase_matcher
 
 MAX_PHRASES = 2048
 MAX_PHRASE_CHARS = 256
-MAX_PENDING_TOKENS = 256
+MAX_ZERO_WIDTH_TOKENS = 256
 MAX_RETRIES = 128
 
 
@@ -43,6 +43,10 @@ class PendingText:
     def __init__(self, phrases: tuple[str, ...], case_sensitive: bool = False):
         self.pattern = compile_phrases(phrases, case_sensitive)
         self.case_sensitive = case_sensitive
+        self.max_pending_tokens = MAX_ZERO_WIDTH_TOKENS + max(
+            max(len(phrase.encode("utf-8")), len(phrase.casefold().encode("utf-8"))) for phrase in phrases
+        )
+        self.zero_width_tokens = 0
         self.state = 0
         self.tokens: list[int] = []
         self.ends: list[int] = []
@@ -81,7 +85,8 @@ class PendingText:
         offset = self.num_bytes
         self.num_bytes += len(data)
         self.ends.append(self.num_bytes)
-        if len(self.tokens) > MAX_PENDING_TOKENS:
+        self.zero_width_tokens = 0 if data else self.zero_width_tokens + 1
+        if len(self.tokens) > self.max_pending_tokens or self.zero_width_tokens > MAX_ZERO_WIDTH_TOKENS:
             raise ValueError("banned_strings pending-token limit exceeded")
         self.state, match, suffix = _phrase_matcher.scan(self.pattern, self.state, data)
         self.states.append(self.state)
@@ -95,6 +100,7 @@ class PendingText:
             self.ends.clear()
             self.states.clear()
             self.num_bytes = 0
+            self.zero_width_tokens = 0
             # Whole-token rollback can reactivate a previously released prefix.
             self.state = self.published_state
             return Decision(ready, self.published, blocked)

--- a/aphrodite/v1/phrase_guard/matcher.py
+++ b/aphrodite/v1/phrase_guard/matcher.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from functools import lru_cache
 
-from aphrodite import _phrase_matcher
+import aphrodite._phrase_matcher as _phrase_matcher
 
 MAX_PHRASES = 2048
 MAX_PHRASE_CHARS = 256

--- a/aphrodite/v1/phrase_guard/processor.py
+++ b/aphrodite/v1/phrase_guard/processor.py
@@ -52,4 +52,8 @@ class PhraseRetryProcessor(LogitsProcessor):
         for row, (output, position, tokens) in self.states.items():
             if len(output) == position:
                 logits[row].index_fill_(0, tokens, float("-inf"))
+                # Return a blocked token as an error sentinel if constraints
+                # exhaust the row. The scheduler discards it before decoding.
+                first = tokens[:1]
+                logits[row].scatter_(0, first, torch.where(logits[row].amax() == -torch.inf, 0.0, logits[row][first]))
         return logits

--- a/aphrodite/v1/phrase_guard/processor.py
+++ b/aphrodite/v1/phrase_guard/processor.py
@@ -40,6 +40,26 @@ class PhraseRetryProcessor(LogitsProcessor):
     def is_argmax_invariant(self) -> bool:
         return False
 
+    @classmethod
+    def validate_runtime(cls, config, tokenizer):
+        from transformers import TokenizersBackend
+
+        from aphrodite.v1.engine import detokenizer
+
+        if not detokenizer.USE_FAST_DETOKENIZER or not isinstance(tokenizer, TokenizersBackend):
+            raise ValueError("Experimental banned_strings requires a fast Hugging Face tokenizer")
+        if config.model_config.return_sampling_mask or config.model_config.enable_return_routed_experts:
+            raise ValueError("Experimental banned_strings does not support sampling masks or routed experts")
+        if not config.use_v2_model_runner and not any(
+            p is cls or p == f"{cls.__module__}:{cls.__name__}" for p in config.model_config.logits_processors or []
+        ):
+            raise ValueError("banned_strings requires the PhraseRetryProcessor logits processor")
+
+    @staticmethod
+    def validate_input(resumable, has_encoder_inputs, prompt_embeds):
+        if resumable or has_encoder_inputs or prompt_embeds is not None:
+            raise ValueError("Experimental banned_strings requires non-resumable plain text generation")
+
     def update_state(self, batch_update: BatchUpdate | None):
         def add(params, prompt, output):
             retry = (params.extra_args or {}).get(RETRY_KEY)

--- a/aphrodite/v1/phrase_guard/processor.py
+++ b/aphrodite/v1/phrase_guard/processor.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from aphrodite.sampling_params import SamplingParams
+from aphrodite.v1.phrase_guard.matcher import validate_phrases
+from aphrodite.v1.sample.logits_processor import BatchUpdate, LogitsProcessor
+from aphrodite.v1.sample.logits_processor.builtin import process_dict_updates
+
+RETRY_KEY = "_sonar_phrase_retry"
+
+
+class PhraseRetryProcessor(LogitsProcessor):
+    """Mask failed alternatives at their checkpoint, never at another position."""
+
+    def __init__(self, aphrodite_config, device, is_pin_memory):
+        self.device = device
+        self.states: dict[int, tuple[list[int], int, torch.Tensor]] = {}
+
+    @classmethod
+    def validate_params(cls, sampling_params: SamplingParams):
+        args = sampling_params.extra_args or {}
+        if "banned_strings" in args:
+            validate_phrases(args["banned_strings"])
+            case_sensitive = args.get("banned_strings_case_sensitive", False)
+            if not isinstance(case_sensitive, (bool, int)) or case_sensitive not in (0, 1):
+                raise ValueError("banned_strings_case_sensitive must be a boolean or 0/1")
+            if (
+                sampling_params.structured_outputs is not None
+                or sampling_params.trace_decode_token_ids is not None
+                or sampling_params.mirostat_mode
+            ):
+                raise ValueError("Experimental banned_strings does not support grammar, replay, or Mirostat")
+        if RETRY_KEY in args:
+            raise ValueError(f"{RETRY_KEY} is reserved for the phrase scheduler")
+
+    def is_argmax_invariant(self) -> bool:
+        return False
+
+    def update_state(self, batch_update: BatchUpdate | None):
+        def add(params, prompt, output):
+            retry = (params.extra_args or {}).get(RETRY_KEY)
+            if retry is None:
+                return None
+            position, tokens = retry
+            return output, position, torch.tensor(tokens, dtype=torch.long, device=self.device)
+
+        process_dict_updates(self.states, batch_update, add)
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        for row, (output, position, tokens) in self.states.items():
+            if len(output) == position:
+                logits[row].index_fill_(0, tokens, float("-inf"))
+        return logits

--- a/aphrodite/v1/phrase_guard/processor.py
+++ b/aphrodite/v1/phrase_guard/processor.py
@@ -26,6 +26,8 @@ class PhraseRetryProcessor(LogitsProcessor):
             case_sensitive = args.get("banned_strings_case_sensitive", False)
             if not isinstance(case_sensitive, (bool, int)) or case_sensitive not in (0, 1):
                 raise ValueError("banned_strings_case_sensitive must be a boolean or 0/1")
+            if sampling_params.stop:
+                raise ValueError("Experimental banned_strings does not support text stop strings; use stop_token_ids")
             if (
                 sampling_params.structured_outputs is not None
                 or sampling_params.trace_decode_token_ids is not None

--- a/aphrodite/v1/phrase_guard/scheduler.py
+++ b/aphrodite/v1/phrase_guard/scheduler.py
@@ -157,6 +157,11 @@ class PhraseScheduler(AsyncScheduler):
         stopped = False
         rewound = False
         for index, token in enumerate(new_token_ids):
+            if request.num_output_tokens == guard.retry_position and token in guard.blocked:
+                logger.error("Phrase retry exhausted sampling constraints for request %s", request.request_id)
+                request.status = RequestStatus.FINISHED_ERROR
+                stopped = True
+                break
             request.append_output_token_ids(token)
             if guard.logprobs is not None:
                 assert guard.step_logprobs is not None

--- a/aphrodite/v1/phrase_guard/scheduler.py
+++ b/aphrodite/v1/phrase_guard/scheduler.py
@@ -166,6 +166,18 @@ class PhraseScheduler(AsyncScheduler):
             if guard.logprobs is not None:
                 assert guard.step_logprobs is not None
                 guard.logprobs.append(guard.step_logprobs, index)
+            params = request.sampling_params
+            stop_token = token == params.eos_token_id or token in (params.stop_token_ids or ())
+            if stop_token and not params.include_stop_str_in_output:
+                # The output detokenizer omits this token's text. Flush the
+                # pending prefix and let it consume the stop token normally.
+                final = guard.pending.finish() + [token]
+                ready.extend(final)
+                if guard.logprobs is not None:
+                    ready_logprobs.extend(guard.logprobs.take(len(final)))
+                check_stop(request, self.max_model_len)
+                stopped = True
+                break
             try:
                 decision = guard.pending.feed(token, guard.decode(token))
             except ValueError:
@@ -179,6 +191,13 @@ class PhraseScheduler(AsyncScheduler):
             if decision.rewind_to is not None:
                 if guard.logprobs is not None:
                     guard.logprobs.clear()
+                if stop_token:
+                    logger.error(
+                        "Banned phrase conflicts with an included stop token for request %s", request.request_id
+                    )
+                    request.status = RequestStatus.FINISHED_ERROR
+                    stopped = True
+                    break
                 guard.retries += 1
                 if guard.retries > MAX_RETRIES:
                     request.status = RequestStatus.FINISHED_ERROR

--- a/aphrodite/v1/phrase_guard/scheduler.py
+++ b/aphrodite/v1/phrase_guard/scheduler.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass, fields, replace
+
+from aphrodite.logger import init_logger
+from aphrodite.sampling_params import SamplingParams
+from aphrodite.tokenizers.registry import cached_tokenizer_from_config
+from aphrodite.v1.core.sched.async_scheduler import AsyncScheduler
+from aphrodite.v1.core.sched.output import SchedulerOutput
+from aphrodite.v1.core.sched.utils import check_stop
+from aphrodite.v1.engine.detokenizer import FastIncrementalDetokenizer, IncrementalDetokenizer
+from aphrodite.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    MambaSpec,
+    MLAAttentionSpec,
+    SlidingWindowMLASpec,
+    SlidingWindowSpec,
+)
+from aphrodite.v1.phrase_guard.logprobs import PendingLogprobs, join_logprobs
+from aphrodite.v1.phrase_guard.matcher import MAX_RETRIES, PendingText, validate_phrases
+from aphrodite.v1.phrase_guard.processor import RETRY_KEY, PhraseRetryProcessor
+from aphrodite.v1.request import RequestStatus
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class PhraseSchedulerOutput(SchedulerOutput):
+    phrase_rewinds: dict[str, tuple[list[int], SamplingParams]] | None = None
+
+
+class RequestGuard:
+    def __init__(self, request, tokenizer):
+        self.request = request
+        self.tokenizer = tokenizer
+        args = request.sampling_params.extra_args
+        self.pending = PendingText(
+            validate_phrases(args["banned_strings"]), bool(args.get("banned_strings_case_sensitive", False))
+        )
+        self.retries = 0
+        self.retry_position = -1
+        self.blocked: list[int] = []
+        self.logprobs = PendingLogprobs() if request.sampling_params.num_logprobs is not None else None
+        self.step_logprobs = None
+        self.output_logprobs = None
+        self.prompt_logprobs = None
+        self.reset_decoder()
+
+    def reset_decoder(self):
+        self.decoder = IncrementalDetokenizer.from_new_request(self.tokenizer, self.request)
+        if not isinstance(self.decoder, FastIncrementalDetokenizer):
+            raise ValueError("Experimental banned_strings requires a fast Hugging Face tokenizer")
+        for token in self.request.output_token_ids:
+            self.decode(token)
+
+    def decode(self, token):
+        self.decoder.token_ids.append(token)
+        return self.decoder.decode_next(token)
+
+
+class PhraseScheduler(AsyncScheduler):
+    """Async phrase rollback with fenced writes and immutable cached prefixes."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        config = self.aphrodite_config
+        if not config.scheduler_config.async_scheduling:
+            raise ValueError("PhraseScheduler requires async_scheduling=True")
+        if self.connector is not None or self.ec_connector is not None:
+            raise ValueError("Experimental PhraseScheduler does not support cache connectors")
+        if not self.cache_config.enable_prefix_caching:
+            raise ValueError("PhraseScheduler requires prefix caching for replay")
+        if any(
+            type(group.kv_cache_spec)
+            not in (
+                FullAttentionSpec,
+                MLAAttentionSpec,
+                MambaSpec,
+                SlidingWindowSpec,
+                SlidingWindowMLASpec,
+                ChunkedLocalAttentionSpec,
+            )
+            for group in self.kv_cache_config.kv_cache_groups
+        ):
+            raise ValueError("Unsupported cache layout for experimental PhraseScheduler")
+        self.guards: dict[str, RequestGuard] = {}
+        self.rewinds: dict[str, tuple[list[int], SamplingParams]] = {}
+        self.tokenizer = None
+        self.defer_block_free = True
+        self.logprob_guards: set[str] = set()
+
+    def add_request(self, request):
+        params = request.sampling_params
+        if params and "banned_strings" in (params.extra_args or {}):
+            PhraseRetryProcessor.validate_params(params)
+            processors = self.aphrodite_config.model_config.logits_processors or []
+            if not self.use_v2_model_runner and not any(
+                p is PhraseRetryProcessor or str(p).endswith("PhraseRetryProcessor") for p in processors
+            ):
+                raise ValueError("banned_strings requires the PhraseRetryProcessor logits processor")
+            if (
+                self.return_sampling_mask
+                or self.enable_return_routed_experts
+                or request.resumable
+                or request.has_encoder_inputs
+                or request.prompt_embeds is not None
+            ):
+                raise ValueError("Experimental banned_strings requires non-resumable plain text generation")
+            if self.tokenizer is None:
+                self.tokenizer = cached_tokenizer_from_config(self.aphrodite_config.model_config)
+            self.guards[request.request_id] = RequestGuard(request, self.tokenizer)
+            if params.num_logprobs is not None or params.prompt_logprobs is not None:
+                self.logprob_guards.add(request.request_id)
+        super().add_request(request)
+
+    def schedule(self, throttle_prefills=False):
+        # Rewound histories must not reach workers until old frames drain.
+        held = []
+        if self.rewinds:
+            held = [r for r in self.waiting if r.request_id in self.rewinds and r.num_in_flight_tokens]
+            self.waiting.remove_requests(held)
+            for rid in self.rewinds:
+                # Retry the checkpoint without drafts from the discarded history.
+                self.requests[rid].spec_token_ids = []
+        try:
+            output = super().schedule(throttle_prefills)
+        finally:
+            for request in reversed(held):
+                self.waiting.prepend_request(request)
+        rewinds = (
+            {rid: self.rewinds.pop(rid) for rid in output.num_scheduled_tokens if rid in self.rewinds}
+            if self.rewinds
+            else None
+        )
+        if rewinds:
+            if self.use_v2_model_runner:
+                for request in output.scheduled_new_reqs:
+                    if request.req_id in rewinds:
+                        request.sampling_params = rewinds[request.req_id][1]
+            else:
+                output = PhraseSchedulerOutput(
+                    **{f.name: getattr(output, f.name) for f in fields(SchedulerOutput)}, phrase_rewinds=rewinds
+                )
+        return output
+
+    def _update_request_with_output(self, request, new_token_ids, is_stale=False):
+        guard = self.guards.get(request.request_id)
+        if guard is None:
+            return super()._update_request_with_output(request, new_token_ids, is_stale)
+        if not is_stale:
+            request.num_output_placeholders -= len(new_token_ids)
+            assert request.num_output_placeholders >= 0
+        ready = []
+        ready_logprobs = []
+        stopped = False
+        rewound = False
+        for index, token in enumerate(new_token_ids):
+            request.append_output_token_ids(token)
+            if guard.logprobs is not None:
+                assert guard.step_logprobs is not None
+                guard.logprobs.append(guard.step_logprobs, index)
+            try:
+                decision = guard.pending.feed(token, guard.decode(token))
+            except ValueError:
+                logger.exception("Phrase guard exhausted its buffer for request %s", request.request_id)
+                request.status = RequestStatus.FINISHED_ERROR
+                stopped = True
+                break
+            ready.extend(decision.ready)
+            if guard.logprobs is not None:
+                ready_logprobs.extend(guard.logprobs.take(len(decision.ready)))
+            if decision.rewind_to is not None:
+                if guard.logprobs is not None:
+                    guard.logprobs.clear()
+                guard.retries += 1
+                if guard.retries > MAX_RETRIES:
+                    request.status = RequestStatus.FINISHED_ERROR
+                    stopped = True
+                    break
+                self._rewind(request, guard, decision)
+                rewound = True
+                break
+            if check_stop(request, self.max_model_len):
+                final = guard.pending.finish()
+                ready.extend(final)
+                if guard.logprobs is not None:
+                    ready_logprobs.extend(guard.logprobs.take(len(final)))
+                stopped = True
+                break
+        guard.output_logprobs = join_logprobs(ready_logprobs)
+        if not stopped and not rewound and request.status == RequestStatus.RUNNING:
+            self.kv_cache_manager.cache_blocks(request, request.num_computed_tokens - request.num_output_placeholders)
+        return ready, stopped
+
+    def _rewind(self, request, guard, decision):
+        position = decision.rewind_to
+        if guard.retry_position != position:
+            guard.retry_position = position
+            guard.blocked.clear()
+        guard.blocked.append(decision.blocked_token)
+        # Resume through cache lookup; published attention blocks and recurrent
+        # checkpoints stay immutable until old GPU writes have drained.
+        if request.status == RequestStatus.RUNNING:
+            self.running.remove(request)
+            self._preempt_request(request, 0.0, drop_stale_output=True)
+        else:
+            request.drop_stale_output = True
+        del request._output_token_ids[position:]
+        del request._all_token_ids[request.num_prompt_tokens + position :]
+        del request.block_hashes[request.num_tokens // self.hash_block_size :]
+        params = request.sampling_params.clone()
+        if self.use_v2_model_runner:
+            # Original prompt probabilities are already buffered or published.
+            params.prompt_logprobs = None
+        params.extra_args = dict(params.extra_args or {})
+        params.extra_args[RETRY_KEY] = (position, guard.blocked.copy())
+        if self.use_v2_model_runner:
+            # Preserve the retry if memory pressure preempts replay again.
+            request.sampling_params = params
+        self.rewinds[request.request_id] = (list(request.output_token_ids), params)
+        guard.reset_decoder()
+        logger.debug("Phrase rewind: request=%s position=%d retries=%d", request.request_id, position, guard.retries)
+
+    def update_from_output(self, scheduler_output, model_runner_output):
+        if not self.logprob_guards:
+            return super().update_from_output(scheduler_output, model_runner_output)
+        guards = {rid: self.guards[rid] for rid in model_runner_output.req_ids if rid in self.logprob_guards}
+        prompt_logprobs = dict(model_runner_output.prompt_logprobs_dict)
+        for rid, guard in guards.items():
+            guard.step_logprobs = None
+            guard.output_logprobs = None
+            if guard.logprobs is not None and model_runner_output.logprobs is not None:
+                index = model_runner_output.req_id_to_index[rid]
+                guard.step_logprobs = model_runner_output.logprobs.slice_request(
+                    index, len(model_runner_output.sampled_token_ids[index])
+                )
+            if rid in prompt_logprobs:
+                guard.prompt_logprobs = prompt_logprobs.pop(rid)
+        outputs = super().update_from_output(
+            scheduler_output, replace(model_runner_output, prompt_logprobs_dict=prompt_logprobs)
+        )
+        for batch in outputs.values():
+            for output in batch.outputs:
+                if guard := guards.get(output.request_id):
+                    output.new_logprobs = guard.output_logprobs
+                    output.new_prompt_logprobs_tensors = guard.prompt_logprobs
+                    guard.prompt_logprobs = None
+        for guard in guards.values():
+            guard.step_logprobs = None
+        return outputs
+
+    def _free_request(self, request, delay_free_blocks=False):
+        result = super()._free_request(request, delay_free_blocks)
+        self.guards.pop(request.request_id, None)
+        self.rewinds.pop(request.request_id, None)
+        self.logprob_guards.discard(request.request_id)
+        return result

--- a/aphrodite/v1/phrase_guard/v2.py
+++ b/aphrodite/v1/phrase_guard/v2.py
@@ -40,15 +40,42 @@ class RetryMask:
             self.counts.gpu,
             self.tokens.gpu,
             WIDTH=MAX_RETRIES,
+            VOCAB_SIZE=logits.shape[1],
+            BLOCK_SIZE=min(4096, triton.next_power_of_2(logits.shape[1])),
         )
 
 
 @triton.jit
-def _mask(logits, stride, mapping, positions, checkpoints, counts, tokens, WIDTH: tl.constexpr):
+def _mask(
+    logits,
+    stride,
+    mapping,
+    positions,
+    checkpoints,
+    counts,
+    tokens,
+    WIDTH: tl.constexpr,
+    VOCAB_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
     row = tl.program_id(0)
     request = tl.load(mapping + row)
-    if tl.load(positions + row) == tl.load(checkpoints + request):
+    count = tl.load(counts + request)
+    if count > 0 and tl.load(positions + row) == tl.load(checkpoints + request):
         offsets = tl.arange(0, WIDTH)
-        valid = offsets < tl.load(counts + request)
+        valid = offsets < count
         ids = tl.load(tokens + request * WIDTH + offsets, valid, other=0)
         tl.store(logits + row * stride + ids, float("-inf"), valid)
+        tl.debug_barrier()
+        vocab = tl.arange(0, BLOCK_SIZE)
+        maximum = float("-inf")
+        start = 0
+        while start < VOCAB_SIZE and maximum == float("-inf"):
+            columns = start + vocab
+            values = tl.load(logits + row * stride + columns, columns < VOCAB_SIZE, other=float("-inf"))
+            maximum = tl.max(values, 0)
+            start += BLOCK_SIZE
+        if maximum == float("-inf"):
+            # Match V1's blocked-token sentinel without a GPU-to-CPU sync.
+            first = tl.load(tokens + request * WIDTH)
+            tl.store(logits + row * stride + first, 0.0)

--- a/aphrodite/v1/phrase_guard/v2.py
+++ b/aphrodite/v1/phrase_guard/v2.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+import torch
+
+from aphrodite.triton_utils import tl, triton
+from aphrodite.v1.phrase_guard.matcher import MAX_RETRIES
+from aphrodite.v1.worker.gpu.buffer_utils import StagedWriteTensor, UvaBackedTensor
+
+
+class RetryMask:
+    def __init__(self, max_num_reqs, device):
+        self.positions = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
+        self.counts = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
+        self.tokens = StagedWriteTensor((max_num_reqs, MAX_RETRIES), dtype=torch.int32, device=device)
+
+    def add_request(self, index, prompt_len, retry):
+        self.counts.np[index] = 0
+        if retry is not None:
+            position, tokens = retry
+            self.positions.np[index] = prompt_len + position - 1
+            self.counts.np[index] = len(tokens)
+            self.tokens.stage_write(index, 0, tokens)
+
+    def apply_staged_writes(self):
+        self.positions.copy_to_uva()
+        self.counts.copy_to_uva()
+        self.tokens.apply_write()
+
+    def apply(self, logits, expanded_idx_mapping, idx_mapping_np, positions):
+        if not np.any(self.counts.np[idx_mapping_np]):
+            return
+        _mask[(logits.shape[0],)](
+            logits,
+            logits.stride(0),
+            expanded_idx_mapping,
+            positions,
+            self.positions.gpu,
+            self.counts.gpu,
+            self.tokens.gpu,
+            WIDTH=MAX_RETRIES,
+        )
+
+
+@triton.jit
+def _mask(logits, stride, mapping, positions, checkpoints, counts, tokens, WIDTH: tl.constexpr):
+    row = tl.program_id(0)
+    request = tl.load(mapping + row)
+    if tl.load(positions + row) == tl.load(checkpoints + request):
+        offsets = tl.arange(0, WIDTH)
+        valid = offsets < tl.load(counts + request)
+        ids = tl.load(tokens + request * WIDTH + offsets, valid, other=0)
+        tl.store(logits + row * stride + ids, float("-inf"), valid)

--- a/aphrodite/v1/phrase_guard/worker.py
+++ b/aphrodite/v1/phrase_guard/worker.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+def restore_requests(runner, rewinds):
+    """Replace only rewound V1 request histories before ordinary cache resume."""
+    for req_id, (output_ids, params) in rewinds.items():
+        state = runner.requests[req_id]
+        runner.input_batch.remove_request(req_id)
+        if runner.input_batch.prev_req_id_to_index is not None:
+            runner.input_batch.prev_req_id_to_index.pop(req_id, None)
+        state.output_token_ids[:] = output_ids
+        state.sampling_params = params
+        state.persistent_data.clear()
+        state.prev_num_draft_len = 0

--- a/aphrodite/v1/sample/logits_processor/__init__.py
+++ b/aphrodite/v1/sample/logits_processor/__init__.py
@@ -186,13 +186,21 @@ def build_logitsprocs(
 
     # Check if speculative decoding is enabled.
     if aphrodite_config.speculative_config:
+        retry_processors = []
         if custom_logitsprocs:
-            raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
+            from aphrodite.v1.phrase_guard.processor import PhraseRetryProcessor
+
+            classes = _load_custom_logitsprocs(custom_logitsprocs)
+            if any(cls is not PhraseRetryProcessor for cls in classes):
+                raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
+            # PhraseScheduler retries checkpoints without speculative drafts.
+            retry_processors = [cls(aphrodite_config, device, is_pin_memory) for cls in classes]
         logger.warning("logit_bias parameter won't work with speculative decoding.")
         return LogitsProcessors(
             [
                 MinTokensLogitsProcessor(aphrodite_config, device, is_pin_memory),
                 MinPLogitsProcessor(aphrodite_config, device, is_pin_memory),
+                *retry_processors,
             ]
         )
 

--- a/aphrodite/v1/worker/gpu/model_runner.py
+++ b/aphrodite/v1/worker/gpu/model_runner.py
@@ -1851,7 +1851,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
 
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None
-        if self.speculator is not None and self.speculator.supports_mm_inputs:
+        if self.speculator is not None and self.speculator.supports_mm_inputs and self.model_state.supports_mm_inputs:
             # Get cached multimodal embeddings for draft forward.
             # NOTE: This is done here because postprocess updates
             # num_computed_prefill_tokens.

--- a/aphrodite/v1/worker/gpu/sample/sampler.py
+++ b/aphrodite/v1/worker/gpu/sample/sampler.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import torch
 
@@ -29,6 +31,9 @@ from aphrodite.v1.worker.gpu.sample.thinking_budget import ThinkingBudgetState
 from aphrodite.v1.worker.gpu.sample.trace_replay import TraceReplayState
 from aphrodite.v1.worker.gpu.states import RequestState
 
+if TYPE_CHECKING:
+    from aphrodite.v1.phrase_guard.v2 import RetryMask
+
 
 class Sampler:
     def __init__(
@@ -56,6 +61,7 @@ class Sampler:
         self.logprob_token_ids_state = LogprobTokenIdsState(max_num_reqs, device)
         self.thinking_budget_state = ThinkingBudgetState(req_states, reasoning_config)
         self.trace_replay_state = TraceReplayState(req_states) if enable_trace_replay else None
+        self.phrase_retry_mask: RetryMask | None = None
         self.needs_logits_processing = np.zeros(max_num_reqs, dtype=bool)
         self.num_speculative_tokens = num_speculative_tokens
         self.return_sampling_mask = return_sampling_mask
@@ -73,8 +79,16 @@ class Sampler:
 
         states = self.sampling_states
         temperature = states.temperature.np[req_idx]
+        retry = (sampling_params.extra_args or {}).get("_sonar_phrase_retry")
+        if retry is not None and self.phrase_retry_mask is None:
+            from aphrodite.v1.phrase_guard.v2 import RetryMask
+
+            self.phrase_retry_mask = RetryMask(self.req_states.max_num_reqs, self.req_states.device)
+        if self.phrase_retry_mask is not None:
+            self.phrase_retry_mask.add_request(req_idx, prompt_len, retry)
         self.needs_logits_processing[req_idx] = (
-            self.logit_bias_state.use_logit_bias[req_idx]
+            retry is not None
+            or self.logit_bias_state.use_logit_bias[req_idx]
             or self.penalties_state.use_penalty[req_idx]
             or self.bad_words_state.num_bad_words.np[req_idx] > 0
             or (self.thinking_budget_state.enabled and self.thinking_budget_state.use_thinking_budget[req_idx])
@@ -85,6 +99,8 @@ class Sampler:
         )
 
     def apply_staged_writes(self) -> None:
+        if self.phrase_retry_mask is not None:
+            self.phrase_retry_mask.apply_staged_writes()
         self.sampling_states.apply_staged_writes()
         self.penalties_state.apply_staged_writes()
         self.logit_bias_state.apply_staged_writes()
@@ -239,6 +255,8 @@ class Sampler:
         )
 
         # Apply temperature in place.
+        if self.phrase_retry_mask is not None:
+            self.phrase_retry_mask.apply(logits, expanded_idx_mapping, idx_mapping_np, pos)
         self.sampling_states.apply_temperature(logits, expanded_idx_mapping, idx_mapping_np)
 
         # Apply min_p in place.

--- a/aphrodite/v1/worker/gpu_model_runner.py
+++ b/aphrodite/v1/worker/gpu_model_runner.py
@@ -1104,6 +1104,11 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin, ECConnec
         The SamplingMetadata is updated and copied to the GPU if there is a
         new/resumed/paused/finished request in the batch.
         """
+        if rewinds := getattr(scheduler_output, "phrase_rewinds", None):
+            from aphrodite.v1.phrase_guard.worker import restore_requests
+
+            restore_requests(self, rewinds)
+
         # Remove finished requests from the cached states.
         for req_id in scheduler_output.finished_req_ids:
             req_state = self.requests.pop(req_id, None)
@@ -1155,7 +1160,11 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin, ECConnec
         for req_id in unscheduled_req_ids:
             self.input_batch.remove_request(req_id)
 
-        is_ngram_gpu = self.speculative_config is not None and self.speculative_config.use_ngram_gpu()
+        is_ngram_gpu = (
+            self.speculative_config is not None
+            and self.speculative_config.use_ngram_gpu()
+            and get_pp_group().is_last_rank
+        )
         if is_ngram_gpu:
             ngram_gpu_new_reqs: list[CachedRequestState] = []
 
@@ -2413,6 +2422,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin, ECConnec
         # Prepare the attention metadata for each KV cache group and make layers
         # in the same group share the same metadata.
         spec_decode_common_attn_metadata = None
+        has_drafter = self.speculative_config is not None and get_pp_group().is_last_rank
         for kv_cache_gid, kv_cache_group in enumerate(kv_cache_groups):
             cm = copy(cm_base)  # shallow copy
 
@@ -2428,7 +2438,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin, ECConnec
                 cm.block_table_tensor = _get_block_table(kv_cache_gid)
                 cm.slot_mapping = slot_mappings[kv_cache_gid]
 
-            if self.speculative_config and spec_decode_common_attn_metadata is None:
+            if has_drafter and spec_decode_common_attn_metadata is None:
                 if isinstance(
                     self.drafter,
                     (
@@ -2443,9 +2453,9 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin, ECConnec
                 else:
                     spec_decode_common_attn_metadata = cm
             # Capture per-group block tables for multi-group proposers.
-            if self.speculative_config and isinstance(self.drafter, Step3p5MTPProposer):
+            if has_drafter and isinstance(self.drafter, Step3p5MTPProposer):
                 self.drafter.set_per_group_attn_metadata(kv_cache_gid, cm.block_table_tensor, cm.slot_mapping)
-            elif self.speculative_config and isinstance(self.drafter, Gemma4Proposer):
+            elif has_drafter and isinstance(self.drafter, Gemma4Proposer):
                 self.drafter.set_per_group_block_table(kv_cache_gid, cm.block_table_tensor)
 
             for attn_gid in range(len(self.attn_groups[kv_cache_gid])):

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -598,7 +598,7 @@ endmacro()
 function (define_extension_target MOD_NAME)
   cmake_parse_arguments(PARSE_ARGV 1
     ARG
-    "WITH_SOABI"
+    "WITH_SOABI;NO_TORCH"
     "DESTINATION;LANGUAGE;USE_SABI"
     "SOURCES;ARCHITECTURES;COMPILE_FLAGS;INCLUDE_DIRECTORIES;LIBRARIES")
 
@@ -646,6 +646,12 @@ function (define_extension_target MOD_NAME)
 
   target_compile_definitions(${MOD_NAME} PRIVATE
     "-DTORCH_EXTENSION_NAME=${MOD_NAME}")
+
+  if (ARG_NO_TORCH)
+    target_link_libraries(${MOD_NAME} PRIVATE ${ARG_LIBRARIES})
+    install(TARGETS ${MOD_NAME} LIBRARY DESTINATION ${ARG_DESTINATION} COMPONENT ${MOD_NAME})
+    return()
+  endif()
 
   target_link_libraries(${MOD_NAME} PRIVATE torch ${ARG_LIBRARIES})
 

--- a/csrc/phrase_matcher.cpp
+++ b/csrc/phrase_matcher.cpp
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <algorithm>
+#include <memory>
+#include <queue>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+constexpr const char* capsule_name = "sonar.phrase_automaton";
+
+struct Node {
+  std::unordered_map<unsigned char, int> edges;
+  int failure = 0;
+  int depth = 0;
+  int terminal = 0;
+};
+
+struct Automaton {
+  std::vector<Node> nodes{1};
+
+  int advance(int state, unsigned char byte) const {
+    while (true) {
+      const auto it = nodes[state].edges.find(byte);
+      if (it != nodes[state].edges.end()) return it->second;
+      if (state == 0) return 0;
+      state = nodes[state].failure;
+    }
+  }
+
+  void add(const std::string& pattern) {
+    int state = 0;
+    for (unsigned char byte : pattern) {
+      auto result = nodes[state].edges.emplace(byte, nodes.size());
+      const int next = result.first->second;
+      if (result.second) {
+        const int depth = nodes[state].depth + 1;
+        nodes.emplace_back();
+        nodes.back().depth = depth;
+      }
+      state = next;
+    }
+    nodes[state].terminal = static_cast<int>(pattern.size());
+  }
+
+  void finish() {
+    std::queue<int> queue;
+    for (const auto& edge : nodes[0].edges) queue.push(edge.second);
+    while (!queue.empty()) {
+      const int parent = queue.front();
+      queue.pop();
+      for (const auto& [byte, child] : nodes[parent].edges) {
+        const int failure = advance(nodes[parent].failure, byte);
+        nodes[child].failure = failure;
+        nodes[child].terminal =
+            std::max(nodes[child].terminal, nodes[failure].terminal);
+        queue.push(child);
+      }
+    }
+  }
+};
+
+void destroy(PyObject* capsule) {
+  delete static_cast<Automaton*>(PyCapsule_GetPointer(capsule, capsule_name));
+}
+
+PyObject* compile(PyObject*, PyObject* patterns) {
+  const Py_ssize_t count = PySequence_Size(patterns);
+  if (count < 0) return nullptr;
+  if (count == 0 || count > 2048) {
+    PyErr_SetString(PyExc_ValueError, "Expected 1..2048 byte patterns");
+    return nullptr;
+  }
+  try {
+    auto automaton = std::make_unique<Automaton>();
+    Py_ssize_t total_bytes = 0;
+    for (Py_ssize_t i = 0; i < count; ++i) {
+      PyObject* item = PySequence_GetItem(patterns, i);
+      if (!item) return nullptr;
+      char* data;
+      Py_ssize_t length;
+      if (PyBytes_AsStringAndSize(item, &data, &length) < 0) {
+        Py_DECREF(item);
+        return nullptr;
+      }
+      total_bytes += length;
+      if (length == 0 || total_bytes > 262144) {
+        Py_DECREF(item);
+        PyErr_SetString(PyExc_ValueError,
+                        "Empty pattern or phrase byte budget exceeded");
+        return nullptr;
+      }
+      // Release the Python reference even if trie allocation throws.
+      std::string pattern;
+      try {
+        pattern.assign(data, length);
+      } catch (...) {
+        Py_DECREF(item);
+        throw;
+      }
+      Py_DECREF(item);
+      automaton->add(pattern);
+    }
+    automaton->finish();
+    PyObject* capsule = PyCapsule_New(automaton.get(), capsule_name, destroy);
+    if (capsule) automaton.release();
+    return capsule;
+  } catch (const std::bad_alloc&) {
+    return PyErr_NoMemory();
+  }
+}
+
+PyObject* scan(PyObject*, PyObject* args) {
+  PyObject* capsule;
+  int state;
+  const char* data;
+  Py_ssize_t length;
+  if (!PyArg_ParseTuple(args, "Oiy#", &capsule, &state, &data, &length))
+    return nullptr;
+  const auto* automaton = static_cast<const Automaton*>(
+      PyCapsule_GetPointer(capsule, capsule_name));
+  if (!automaton) return nullptr;
+  if (state < 0 || static_cast<size_t>(state) >= automaton->nodes.size()) {
+    PyErr_SetString(PyExc_ValueError, "Invalid phrase automaton state");
+    return nullptr;
+  }
+  bool found = false;
+  Py_ssize_t earliest = 0;
+  for (Py_ssize_t i = 0; i < length; ++i) {
+    state = automaton->advance(state, static_cast<unsigned char>(data[i]));
+    const int terminal = automaton->nodes[state].terminal;
+    if (terminal) {
+      const Py_ssize_t start = i + 1 - terminal;
+      if (!found || start < earliest) earliest = start;
+      found = true;
+    }
+  }
+  PyObject* match;
+  if (found) {
+    match = PyLong_FromSsize_t(earliest);
+    if (!match) return nullptr;
+  } else {
+    match = Py_None;
+    Py_INCREF(match);
+  }
+  return Py_BuildValue("(iNn)", state, match,
+                       static_cast<Py_ssize_t>(automaton->nodes[state].depth));
+}
+
+PyMethodDef methods[] = {
+    {"compile", compile, METH_O, nullptr},
+    {"scan", scan, METH_VARARGS, nullptr},
+    {nullptr, nullptr, 0, nullptr},
+};
+PyModuleDef module = {PyModuleDef_HEAD_INIT,
+                      "_phrase_matcher",
+                      nullptr,
+                      -1,
+                      methods,
+                      nullptr,
+                      nullptr,
+                      nullptr,
+                      nullptr};
+}  // namespace
+
+PyMODINIT_FUNC PyInit__phrase_matcher() { return PyModule_Create(&module); }

--- a/setup.py
+++ b/setup.py
@@ -636,6 +636,8 @@ def get_requirements() -> list[str]:
 
 ext_modules = []
 
+ext_modules.append(CMakeExtension(name="aphrodite._phrase_matcher"))
+
 if _is_cuda() or _is_hip():
     ext_modules.append(CMakeExtension(name="aphrodite.cumem_allocator"))
     # Optional since this doesn't get built (produce an .so file). This is just

--- a/tests/v1/core/test_phrase_scheduler.py
+++ b/tests/v1/core/test_phrase_scheduler.py
@@ -134,6 +134,25 @@ def test_rewind_preserves_other_request_and_resumes_prefix(scheduler, v2):
     assert next(o for o in outputs if o.request_id == a.request_id).new_token_ids == [13]
 
 
+@pytest.mark.parametrize("v2", [False, True])
+def test_exhausted_retry_finishes_only_affected_request(scheduler, v2):
+    scheduler.use_v2_model_runner = v2
+    a, b = add_requests(scheduler)
+    scheduler.guards[a.request_id].pending = PendingText(("Once",))
+    a.sampling_params.allowed_token_ids = [10]
+    accept(scheduler, scheduler.schedule(), {a.request_id: 10, b.request_id: 20})
+    assert a.status == RequestStatus.PREEMPTED
+    batches = accept(scheduler, scheduler.schedule(), {a.request_id: 10, b.request_id: 20})
+    output = next(o for batch in batches.values() for o in batch.outputs if o.request_id == a.request_id)
+    assert a.status == RequestStatus.FINISHED_ERROR
+    assert output.finish_reason is not None
+    assert not output.new_token_ids
+    assert not a.output_token_ids
+    assert a.request_id not in scheduler.rewinds
+    assert b.status == RequestStatus.RUNNING
+    assert list(b.output_token_ids) == [20, 20]
+
+
 def test_complete_ban_checked_before_length_limit(scheduler):
     a, b = add_requests(scheduler)
     a.max_tokens = 3

--- a/tests/v1/core/test_phrase_scheduler.py
+++ b/tests/v1/core/test_phrase_scheduler.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from aphrodite.v1.outputs import LogprobsLists, ModelRunnerOutput
+from aphrodite.v1.phrase_guard.logprobs import PendingLogprobs
+from aphrodite.v1.phrase_guard.matcher import PendingText
+from aphrodite.v1.phrase_guard.processor import PhraseRetryProcessor
+from aphrodite.v1.phrase_guard.scheduler import PhraseScheduler
+from aphrodite.v1.request import RequestStatus
+from tests.v1.core.utils import create_requests, create_scheduler
+
+pytestmark = pytest.mark.cpu_test
+
+
+class FakeGuard:
+    def __init__(self, request, tokenizer):
+        self.pending = PendingText(("Once upon time",))
+        self.retries = 0
+        self.retry_position = -1
+        self.blocked = []
+        self.logprobs = None
+
+    def decode(self, token):
+        return {10: "Once", 11: " upon", 12: " time", 13: "Fine."}[token]
+
+    def reset_decoder(self):
+        pass
+
+
+@pytest.fixture
+def scheduler(monkeypatch):
+    monkeypatch.setenv("APHRODITE_USE_V2_MODEL_RUNNER", "0")
+    with patch("tests.v1.core.utils.AsyncScheduler", PhraseScheduler):
+        result = create_scheduler(async_scheduling=True, enable_prefix_caching=True, use_v2_model_runner=False)
+    result.tokenizer = object()
+    result.aphrodite_config.model_config.logits_processors = [PhraseRetryProcessor]
+    return result
+
+
+def add_requests(scheduler):
+    a, b = create_requests(2, num_tokens=48, same_prompt=True, max_tokens=24)
+    a.sampling_params = a.sampling_params.clone()
+    a.sampling_params.extra_args = {"banned_strings": ["Once upon time"]}
+    with patch("aphrodite.v1.phrase_guard.scheduler.RequestGuard", FakeGuard):
+        scheduler.add_request(a)
+        scheduler.add_request(b)
+    return a, b
+
+
+def accept(scheduler, scheduled, tokens):
+    req_ids = list(scheduled.num_scheduled_tokens)
+    return scheduler.update_from_output(
+        scheduled,
+        ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index={rid: i for i, rid in enumerate(req_ids)},
+            sampled_token_ids=[[tokens[rid]] for rid in req_ids],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+
+def test_rewind_drains_old_frames_without_stalling_other_requests(scheduler):
+    a, b = add_requests(scheduler)
+    first = scheduler.schedule()
+    second = scheduler.schedule()
+    assert a.request_id in first.num_scheduled_tokens
+    assert a.request_id in second.num_scheduled_tokens
+    assert b.request_id in second.num_scheduled_tokens
+    assert set(scheduler.running) == {a, b}
+    accept(scheduler, first, {a.request_id: 10, b.request_id: 20})
+    third = scheduler.schedule()
+    accept(scheduler, second, {a.request_id: 11, b.request_id: 20})
+    fourth = scheduler.schedule()
+    old_tail = scheduler.kv_cache_manager.get_blocks(a.request_id).blocks[0][-1]
+    accept(scheduler, third, {a.request_id: 12, b.request_id: 20})
+    assert a.num_in_flight_tokens > 0
+    assert old_tail.ref_cnt > 0
+    fenced = scheduler.schedule()
+    assert a.request_id not in fenced.num_scheduled_tokens
+    assert b.request_id in fenced.num_scheduled_tokens
+    assert scheduler.has_requests()
+    accept(scheduler, fourth, {a.request_id: 10, b.request_id: 20})
+    assert old_tail.ref_cnt == 0
+    assert not a.output_token_ids
+    assert a.num_in_flight_tokens == 0
+    accept(scheduler, fenced, {b.request_id: 20})
+    resumed = scheduler.schedule()
+    assert a.request_id in resumed.phrase_rewinds
+    accept(scheduler, resumed, {a.request_id: 13, b.request_id: 20})
+    assert list(a.output_token_ids) == [13]
+    assert list(b.output_token_ids) == [20] * 6
+
+
+@pytest.mark.parametrize("v2", [False, True])
+def test_rewind_preserves_other_request_and_resumes_prefix(scheduler, v2):
+    scheduler.use_v2_model_runner = v2
+    a, b = add_requests(scheduler)
+    published = []
+    for token in [10, 11, 12]:
+        scheduled = scheduler.schedule()
+        before = scheduler.kv_cache_manager.get_block_ids(b.request_id)
+        batches = accept(scheduler, scheduled, {a.request_id: token, b.request_id: 20})
+        for batch in batches.values():
+            for output in batch.outputs:
+                if output.request_id == a.request_id:
+                    published.extend(output.new_token_ids)
+        assert scheduler.kv_cache_manager.get_block_ids(b.request_id) == before
+    assert published == []
+    assert a.status == RequestStatus.PREEMPTED
+    assert list(a.output_token_ids) == []
+    assert list(b.output_token_ids) == [20, 20, 20]
+    assert a.num_output_placeholders == 0
+    assert a.num_in_flight_tokens == 0
+    resumed = scheduler.schedule()
+    if v2:
+        restored = next(r for r in resumed.scheduled_new_reqs if r.req_id == a.request_id)
+        assert restored.sampling_params.extra_args["_sonar_phrase_retry"] == (0, [10])
+        assert a.sampling_params is restored.sampling_params
+        assert restored.num_computed_tokens >= 32
+    else:
+        assert a.request_id in resumed.phrase_rewinds
+        row = resumed.scheduled_cached_reqs.req_ids.index(a.request_id)
+        assert resumed.scheduled_cached_reqs.num_computed_tokens[row] >= 32
+    batches = accept(scheduler, resumed, {a.request_id: 13, b.request_id: 20})
+    outputs = [o for batch in batches.values() for o in batch.outputs]
+    assert next(o for o in outputs if o.request_id == a.request_id).new_token_ids == [13]
+
+
+def test_complete_ban_checked_before_length_limit(scheduler):
+    a, b = add_requests(scheduler)
+    a.max_tokens = 3
+    for token in [10, 11, 12]:
+        accept(scheduler, scheduler.schedule(), {a.request_id: token, b.request_id: 20})
+    assert a.status == RequestStatus.PREEMPTED
+    assert not a.output_token_ids
+
+
+def test_rewind_carries_exact_output_position(scheduler):
+    a, b = add_requests(scheduler)
+    for token in [13, 10, 11, 12]:
+        accept(scheduler, scheduler.schedule(), {a.request_id: token, b.request_id: 20})
+    assert list(a.output_token_ids) == [13]
+    assert scheduler.rewinds[a.request_id][1].extra_args["_sonar_phrase_retry"] == (1, [10])
+
+
+def test_ban_detected_in_output_of_memory_preempted_request(scheduler):
+    a, b = add_requests(scheduler)
+    for token in [10, 11]:
+        accept(scheduler, scheduler.schedule(), {a.request_id: token, b.request_id: 20})
+    last = scheduler.schedule()
+    scheduler.running.remove(a)
+    scheduler._preempt_request(a, 0.0)
+    accept(scheduler, last, {a.request_id: 12, b.request_id: 20})
+    assert a.num_output_placeholders == 0
+    resumed = scheduler.schedule()
+    assert a.request_id in resumed.phrase_rewinds
+    accept(scheduler, resumed, {a.request_id: 13, b.request_id: 20})
+    assert list(a.output_token_ids) == [13]
+
+
+def test_abort_during_rewind_drains_without_resuming(scheduler):
+    a, b = add_requests(scheduler)
+    for token in [10, 11]:
+        accept(scheduler, scheduler.schedule(), {a.request_id: token, b.request_id: 20})
+    hit = scheduler.schedule()
+    stale = scheduler.schedule()
+    accept(scheduler, hit, {a.request_id: 12, b.request_id: 20})
+    scheduler.finish_requests(a.request_id, RequestStatus.FINISHED_ABORTED)
+    assert a.request_id not in scheduler.guards
+    assert a.request_id not in scheduler.rewinds
+    accept(scheduler, stale, {a.request_id: 10, b.request_id: 20})
+    assert a.request_id not in scheduler.schedule().num_scheduled_tokens
+
+
+def test_logprobs_follow_held_tokens_and_discard_rejected_rows(scheduler):
+    a, b = add_requests(scheduler)
+    a.sampling_params.logprobs = 1
+    guard = scheduler.guards[a.request_id]
+    guard.logprobs = PendingLogprobs()
+    guard.prompt_logprobs = None
+    scheduler.logprob_guards.add(a.request_id)
+    published = []
+    prompt_rows = object()
+    published_prompt_rows = []
+    for token in [10, 11, 12, 13]:
+        scheduled = scheduler.schedule()
+        ids = list(scheduled.num_scheduled_tokens)
+        tokens = [[token if rid == a.request_id else 20] for rid in ids]
+        batches = scheduler.update_from_output(
+            scheduled,
+            ModelRunnerOutput(
+                req_ids=ids,
+                req_id_to_index={rid: i for i, rid in enumerate(ids)},
+                sampled_token_ids=tokens,
+                logprobs=LogprobsLists(np.array(tokens), np.full((len(ids), 1), -0.5), np.ones(len(ids))),
+                prompt_logprobs_dict={a.request_id: prompt_rows} if token == 10 else {},
+                pooler_output=[],
+            ),
+        )
+        for batch in batches.values():
+            for output in batch.outputs:
+                if output.request_id == a.request_id:
+                    assert output.new_logprobs.logprob_token_ids[:, 0].tolist() == output.new_token_ids
+                    published.extend(output.new_token_ids)
+                    if output.new_prompt_logprobs_tensors is not None:
+                        published_prompt_rows.append(output.new_prompt_logprobs_tensors)
+    assert published == [13]
+    assert published_prompt_rows == [prompt_rows]
+    assert not guard.logprobs.rows
+
+
+def test_speculative_packet_discards_tokens_after_first_match(scheduler):
+    a, _ = add_requests(scheduler)
+    scheduler.schedule()
+    a.num_output_placeholders = 4
+    ready, stopped = scheduler._update_request_with_output(a, [10, 11, 12, 13])
+    assert ready == []
+    assert not stopped
+    assert not a.output_token_ids
+    assert a.status == RequestStatus.PREEMPTED
+    assert scheduler.rewinds[a.request_id][1].extra_args["_sonar_phrase_retry"] == (0, [10])

--- a/tests/v1/core/test_phrase_scheduler.py
+++ b/tests/v1/core/test_phrase_scheduler.py
@@ -153,6 +153,28 @@ def test_exhausted_retry_finishes_only_affected_request(scheduler, v2):
     assert list(b.output_token_ids) == [20, 20]
 
 
+@pytest.mark.parametrize("include_stop", [False, True])
+@pytest.mark.parametrize("eos", [False, True])
+def test_stop_token_completing_phrase_terminates_without_retry(scheduler, include_stop, eos):
+    a, b = add_requests(scheduler)
+    a.sampling_params.include_stop_str_in_output = include_stop
+    if eos:
+        a.sampling_params._eos_token_id = 12
+    else:
+        a.sampling_params.stop_token_ids = [12]
+    for token in [10, 11, 12]:
+        batches = accept(scheduler, scheduler.schedule(), {a.request_id: token, b.request_id: 20})
+    output = next(o for batch in batches.values() for o in batch.outputs if o.request_id == a.request_id)
+    assert a.request_id not in scheduler.rewinds
+    if include_stop:
+        assert a.status == RequestStatus.FINISHED_ERROR
+        assert output.new_token_ids == []
+    else:
+        assert a.status == RequestStatus.FINISHED_STOPPED
+        assert output.new_token_ids == [10, 11, 12]
+    assert b.status == RequestStatus.RUNNING
+
+
 def test_complete_ban_checked_before_length_limit(scheduler):
     a, b = add_requests(scheduler)
     a.max_tokens = 3

--- a/tests/v1/sample/test_phrase_guard.py
+++ b/tests/v1/sample/test_phrase_guard.py
@@ -152,6 +152,60 @@ def test_compiled_cache_has_weighted_budget(monkeypatch):
         matcher._pattern_cache.clear()
 
 
+@pytest.mark.parametrize(
+    "case", ["missing", "slow", "disabled_fast", "v1_missing_processor", "sampling_mask", "routed", "ok"]
+)
+def test_runtime_requirements_are_validated_before_core_dispatch(monkeypatch, case):
+    from unittest.mock import patch
+
+    from tokenizers import Tokenizer, models
+    from transformers import TokenizersBackend
+
+    from aphrodite.v1.engine import detokenizer
+    from aphrodite.v1.engine.input_processor import InputProcessor
+    from aphrodite.v1.phrase_guard.scheduler import PhraseScheduler
+
+    tokenizer = TokenizersBackend(tokenizer_object=Tokenizer(models.WordLevel({"hello": 0}, unk_token="hello")))
+    if case == "missing":
+        tokenizer = None
+    elif case == "slow":
+        tokenizer = object()
+    monkeypatch.setattr(detokenizer, "USE_FAST_DETOKENIZER", case != "disabled_fast")
+    model_config = SimpleNamespace(
+        return_sampling_mask=case == "sampling_mask",
+        enable_return_routed_experts=case == "routed",
+        logits_processors=[],
+    )
+    processor = SimpleNamespace(
+        tokenizer=tokenizer,
+        aphrodite_config=SimpleNamespace(
+            model_config=model_config,
+            use_v2_model_runner=case != "v1_missing_processor",
+            scheduler_config=SimpleNamespace(get_scheduler_cls=lambda: PhraseScheduler),
+        ),
+        model_config=model_config,
+        speculative_config=None,
+        structured_outputs_config=None,
+    )
+    params = SamplingParams(extra_args={"banned_strings": ["hello"]})
+    with patch.object(SamplingParams, "verify") as verify:
+        if case == "ok":
+            InputProcessor._validate_params(processor, params, ("generate",))
+            verify.assert_called_once()
+        else:
+            with pytest.raises(ValueError, match="banned_strings"):
+                InputProcessor._validate_params(processor, params, ("generate",))
+            verify.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "resumable,encoder,embeds", [(True, False, None), (False, True, None), (False, False, object())]
+)
+def test_non_text_inputs_rejected_before_core_dispatch(resumable, encoder, embeds):
+    with pytest.raises(ValueError, match="non-resumable plain text"):
+        PhraseRetryProcessor.validate_input(resumable, encoder, embeds)
+
+
 def test_retry_mask_moves_with_request_and_only_applies_at_checkpoint():
     processor = PhraseRetryProcessor(None, torch.device("cpu"), False)
     output = [7, 8]

--- a/tests/v1/sample/test_phrase_guard.py
+++ b/tests/v1/sample/test_phrase_guard.py
@@ -115,6 +115,19 @@ def test_retry_mask_moves_with_request_and_only_applies_at_checkpoint():
     assert not processor.states
 
 
+def test_exhausted_retry_returns_blocked_sentinel_only_for_affected_row():
+    processor = PhraseRetryProcessor(None, torch.device("cpu"), False)
+    params = SamplingParams(extra_args={RETRY_KEY: (0, [3, 5])})
+    processor.update_state(BatchUpdate(2, [], [(0, params, [1], [])], []))
+    logits = torch.zeros(2, 10)
+    logits[0] = -torch.inf
+    logits[0, 5] = 2.0
+    processor.apply(logits)
+    assert logits[0].argmax().item() == 3
+    assert torch.isfinite(logits[0]).sum().item() == 1
+    assert not logits[1].count_nonzero().item()
+
+
 def test_restore_does_not_change_other_request_or_rng():
     from unittest.mock import Mock
 

--- a/tests/v1/sample/test_phrase_guard.py
+++ b/tests/v1/sample/test_phrase_guard.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from aphrodite.sampling_params import SamplingParams
+from aphrodite.v1.phrase_guard.matcher import MAX_PENDING_TOKENS, PendingText, validate_phrases
+from aphrodite.v1.phrase_guard.processor import RETRY_KEY, PhraseRetryProcessor
+from aphrodite.v1.phrase_guard.worker import restore_requests
+from aphrodite.v1.sample.logits_processor.interface import BatchUpdate, MoveDirectionality
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_partial_phrase_is_held_then_rewound():
+    guard = PendingText(("a testament to",))
+    assert guard.feed(1, "This is ").ready == [1]
+    assert guard.feed(2, "a test").ready == []
+    assert guard.feed(3, "ament ").ready == []
+    result = guard.feed(4, "to")
+    assert result.ready == []
+    assert result.rewind_to == 1
+    assert result.blocked_token == 2
+    assert guard.feed(5, "excellent").ready == [5]
+
+
+def test_diverging_prefix_releases_without_delay():
+    guard = PendingText(("hello world",))
+    assert guard.feed(1, "hello ").ready == []
+    assert guard.feed(2, "there").ready == [1, 2]
+
+
+def test_match_inside_token_rewinds_entire_token():
+    guard = PendingText(("forbidden",))
+    result = guard.feed(9, "a forbidden sentence")
+    assert result.rewind_to == 0
+    assert result.blocked_token == 9
+    assert result.ready == []
+
+
+def test_overlapping_earlier_partial_cannot_leak():
+    guard = PendingText(("abcdef", "bc"))
+    assert guard.feed(1, "a").ready == []
+    result = guard.feed(2, "bc")
+    assert result.ready == []
+    assert result.rewind_to == 0
+    assert result.blocked_token == 1
+
+
+def test_rollback_restores_prefix_at_published_token_boundary():
+    guard = PendingText(("ab", "cd"))
+    assert guard.feed(1, "a").ready == []
+    assert guard.feed(2, "xc").ready == [1]
+    assert guard.feed(3, "d").rewind_to == 1
+    result = guard.feed(4, "b")
+    assert result.ready == []
+    assert result.rewind_to == 1
+    assert guard.feed(5, "z").ready == [5]
+
+
+def test_unicode_spanning_tokens_and_casefold():
+    guard = PendingText(("é",))
+    assert guard.feed(1, "").ready == []
+    result = guard.feed(2, "É")
+    assert result.rewind_to == 0
+    assert result.blocked_token == 1
+    guard = PendingText(("straße",))
+    assert guard.feed(1, "STRAS").ready == []
+    assert guard.feed(2, "SE").rewind_to == 0
+
+
+def test_case_sensitive_and_literal_regex_characters():
+    guard = PendingText(("[a-z]+",), case_sensitive=True)
+    assert guard.feed(1, "abc").ready == [1]
+    assert guard.feed(2, "[A-Z]+").ready == [2]
+    assert guard.feed(3, "[a-z]+").rewind_to == 2
+
+
+def test_incomplete_prefix_can_finish():
+    guard = PendingText(("hello world",))
+    assert guard.feed(1, "hello").ready == []
+    assert guard.finish() == [1]
+    assert guard.finish() == []
+
+
+def test_zero_width_buffer_is_bounded():
+    guard = PendingText(("hello",))
+    for _ in range(MAX_PENDING_TOKENS):
+        assert guard.feed(1, "").ready == []
+    with pytest.raises(ValueError, match="pending-token"):
+        guard.feed(1, "")
+
+
+@pytest.mark.parametrize("value", [None, [], "hello", [""], [3], ["x" * 257]])
+def test_invalid_phrase_lists(value):
+    with pytest.raises(ValueError):
+        validate_phrases(value)
+
+
+def test_retry_mask_moves_with_request_and_only_applies_at_checkpoint():
+    processor = PhraseRetryProcessor(None, torch.device("cpu"), False)
+    output = [7, 8]
+    params = SamplingParams(extra_args={RETRY_KEY: (2, [3, 5])})
+    processor.update_state(BatchUpdate(2, [], [(0, params, [1], output)], []))
+    processor.update_state(BatchUpdate(2, [], [], [(0, 1, MoveDirectionality.SWAP)]))
+    logits = processor.apply(torch.zeros(2, 10))
+    assert torch.isfinite(logits[0]).all()
+    assert torch.isneginf(logits[1, [3, 5]]).all()
+    output.append(9)
+    assert torch.isfinite(processor.apply(torch.zeros(2, 10))).all()
+    processor.update_state(BatchUpdate(1, [1], [], []))
+    assert not processor.states
+
+
+def test_restore_does_not_change_other_request_or_rng():
+    from unittest.mock import Mock
+
+    states = {
+        rid: SimpleNamespace(
+            output_token_ids=[1, 2, 3],
+            sampling_params=None,
+            persistent_data={"old": 1},
+            prev_num_draft_len=0,
+            generator=object(),
+        )
+        for rid in ("a", "b")
+    }
+    runner = SimpleNamespace(requests=states, input_batch=Mock())
+    rng = states["a"].generator
+    restore_requests(runner, {"a": ([1], SamplingParams())})
+    assert states["a"].output_token_ids == [1]
+    assert states["a"].generator is rng
+    assert states["b"].output_token_ids == [1, 2, 3]
+    assert states["b"].persistent_data == {"old": 1}
+    runner.input_batch.remove_request.assert_called_once_with("a")

--- a/tests/v1/sample/test_phrase_guard.py
+++ b/tests/v1/sample/test_phrase_guard.py
@@ -130,6 +130,28 @@ def test_case_sensitive_byte_budget_is_checked_before_native_compilation():
         PhraseRetryProcessor.validate_params(params)
 
 
+def test_compiled_cache_has_weighted_budget(monkeypatch):
+    from aphrodite.v1.phrase_guard import matcher
+
+    matcher._pattern_cache.clear()
+    monkeypatch.setattr(matcher._phrase_matcher, "compile", lambda _: object())
+    try:
+        small = matcher.compile_phrases(("hello",), False)
+        assert matcher.compile_phrases(("hello",), False) is small
+        for i in range(4):
+            phrases = tuple(f"{i}:{j:03d}" + "x" * 251 for j in range(256))
+            matcher.compile_phrases(phrases, False)
+            assert matcher._pattern_cache.currsize == 69
+        assert matcher.compile_phrases(("hello",), False) is small
+        for i in range(4):
+            phrases = tuple(f"{i}:{j:03d}" + "x" * 251 for j in range(128))
+            matcher.compile_phrases(phrases, False)
+            assert matcher._pattern_cache.currsize <= matcher._pattern_cache.maxsize
+        assert matcher.compile_phrases(("hello",), False) is not small
+    finally:
+        matcher._pattern_cache.clear()
+
+
 def test_retry_mask_moves_with_request_and_only_applies_at_checkpoint():
     processor = PhraseRetryProcessor(None, torch.device("cpu"), False)
     output = [7, 8]

--- a/tests/v1/sample/test_phrase_guard.py
+++ b/tests/v1/sample/test_phrase_guard.py
@@ -122,6 +122,14 @@ def test_invalid_phrase_lists(value):
         validate_phrases(value)
 
 
+def test_case_sensitive_byte_budget_is_checked_before_native_compilation():
+    phrases = ["K" * 246 + "".join("ſ" if i & (1 << bit) else "K" for bit in range(10)) for i in range(1024)]
+    assert sum(len(phrase.casefold().encode("utf-8")) for phrase in phrases) == 262144
+    params = SamplingParams(extra_args={"banned_strings": phrases, "banned_strings_case_sensitive": True})
+    with pytest.raises(ValueError, match="256 KiB"):
+        PhraseRetryProcessor.validate_params(params)
+
+
 def test_retry_mask_moves_with_request_and_only_applies_at_checkpoint():
     processor = PhraseRetryProcessor(None, torch.device("cpu"), False)
     output = [7, 8]

--- a/tests/v1/sample/test_phrase_guard.py
+++ b/tests/v1/sample/test_phrase_guard.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 from aphrodite.sampling_params import SamplingParams
-from aphrodite.v1.phrase_guard.matcher import MAX_PENDING_TOKENS, PendingText, validate_phrases
+from aphrodite.v1.phrase_guard.matcher import MAX_ZERO_WIDTH_TOKENS, PendingText, validate_phrases
 from aphrodite.v1.phrase_guard.processor import RETRY_KEY, PhraseRetryProcessor
 from aphrodite.v1.phrase_guard.worker import restore_requests
 from aphrodite.v1.sample.logits_processor.interface import BatchUpdate, MoveDirectionality
@@ -88,10 +88,32 @@ def test_incomplete_prefix_can_finish():
 
 def test_zero_width_buffer_is_bounded():
     guard = PendingText(("hello",))
-    for _ in range(MAX_PENDING_TOKENS):
+    for _ in range(MAX_ZERO_WIDTH_TOKENS):
         assert guard.feed(1, "").ready == []
     with pytest.raises(ValueError, match="pending-token"):
         guard.feed(1, "")
+
+
+@pytest.mark.parametrize("character", ["😀", "İ"])
+def test_max_length_unicode_phrase_with_byte_fallback(character):
+    phrase = character * 256
+    guard = PendingText(validate_phrases([phrase]))
+    for index, char in enumerate(phrase):
+        for _ in range(len(char.encode("utf-8")) - 1):
+            assert guard.feed(1, "").ready == []
+        decision = guard.feed(2, char)
+        assert decision.ready == []
+        assert decision.rewind_to == (0 if index == 255 else None)
+    assert decision.blocked_token == 1
+
+
+def test_text_stops_cannot_be_hidden_by_phrase_buffer():
+    params = SamplingParams(stop=["a"], extra_args={"banned_strings": ["abc"]})
+    with pytest.raises(ValueError, match="text stop strings"):
+        PhraseRetryProcessor.validate_params(params)
+    params.stop = []
+    params.stop_token_ids = [123]
+    PhraseRetryProcessor.validate_params(params)
 
 
 @pytest.mark.parametrize("value", [None, [], "hello", [""], [3], ["x" * 257]])

--- a/tests/v1/sample/test_phrase_retry_gpu.py
+++ b/tests/v1/sample/test_phrase_retry_gpu.py
@@ -29,6 +29,47 @@ def test_retry_mask_only_changes_checkpoint_rows_and_clears_reused_slots():
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("guard_first", [False, True])
+@pytest.mark.parametrize("greedy", [False, True])
+def test_v1_retry_in_mixed_speculative_batch(guard_first, greedy):
+    from aphrodite.sampling_params import SamplingParams
+    from aphrodite.v1.phrase_guard.processor import RETRY_KEY, PhraseRetryProcessor
+    from aphrodite.v1.sample.logits_processor import BatchUpdate, LogitsProcessors
+    from aphrodite.v1.sample.rejection_sampler import RejectionSampler
+    from aphrodite.v1.sample.sampler import Sampler
+    from aphrodite.v1.spec_decode.metadata import SpecDecodeMetadata
+    from tests.v1.sample.test_rejection_sampler import create_sampling_metadata
+
+    device = torch.device("cuda")
+    guard_row = 0 if guard_first else 1
+    neighbor_row = 1 - guard_row
+    histories = [[], []]
+    processor = PhraseRetryProcessor(None, device, False)
+    params = SamplingParams(extra_args={RETRY_KEY: (0, [4])})
+    processor.update_state(BatchUpdate(2, [], [(guard_row, params, [0], histories[guard_row])], []))
+    drafts = [[], [1, 2]] if guard_first else [[1, 2], []]
+    metadata = SpecDecodeMetadata.make_dummy(drafts, device)
+    metadata.target_logits_indices = torch.tensor([1, 2] if guard_first else [0, 1], device=device)
+    metadata.bonus_logits_indices = torch.tensor([0, 3] if guard_first else [2, 3], device=device)
+    logits = torch.full((4, 16), -torch.inf, device=device)
+    retry_index = 0 if guard_first else 3
+    logits[retry_index, 4] = 10.0
+    logits[retry_index, 5] = 0.0
+    start = 1 if guard_first else 0
+    for offset, token in enumerate([1, 2, 3]):
+        logits[start + offset, token] = 0.0
+    sampling = create_sampling_metadata(
+        all_greedy=greedy,
+        temperature=torch.full((2,), 0.7, device=device),
+        output_token_ids=histories,
+        logitsprocs=LogitsProcessors([processor]),
+    )
+    result = RejectionSampler(Sampler())(metadata, None, logits, sampling).sampled_token_ids.tolist()
+    assert result[guard_row] == [5, -1, -1]
+    assert result[neighbor_row] == [1, 2, 3]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 @pytest.mark.parametrize("vocab_size", [16, 151936, 256128])
 def test_exhausted_retry_returns_sentinel_without_changing_other_rows(vocab_size):
     mask = RetryMask(2, torch.device("cuda"))

--- a/tests/v1/sample/test_phrase_retry_gpu.py
+++ b/tests/v1/sample/test_phrase_retry_gpu.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+import pytest
+import torch
+
+from aphrodite.v1.phrase_guard.v2 import RetryMask
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_retry_mask_only_changes_checkpoint_rows_and_clears_reused_slots():
+    mask = RetryMask(3, torch.device("cuda"))
+    mask.add_request(2, 12, (3, [4, 7]))
+    mask.add_request(0, 10, None)
+    mask.apply_staged_writes()
+    mapping = torch.tensor([2, 2, 0, 2], device="cuda")
+    positions = torch.tensor([14, 15, 14, 16], device="cuda")
+    logits = torch.zeros((4, 16), device="cuda")
+    mask.apply(logits, mapping, np.array([2, 0]), positions)
+    expected = torch.zeros_like(logits)
+    expected[0, [4, 7]] = -torch.inf
+    torch.testing.assert_close(logits, expected)
+    mask.add_request(2, 12, None)
+    mask.apply_staged_writes()
+    logits.zero_()
+    mask.apply(logits, mapping, np.array([2, 0]), positions)
+    assert not logits.count_nonzero().item()

--- a/tests/v1/sample/test_phrase_retry_gpu.py
+++ b/tests/v1/sample/test_phrase_retry_gpu.py
@@ -26,3 +26,22 @@ def test_retry_mask_only_changes_checkpoint_rows_and_clears_reused_slots():
     logits.zero_()
     mask.apply(logits, mapping, np.array([2, 0]), positions)
     assert not logits.count_nonzero().item()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("vocab_size", [16, 151936, 256128])
+def test_exhausted_retry_returns_sentinel_without_changing_other_rows(vocab_size):
+    mask = RetryMask(2, torch.device("cuda"))
+    mask.add_request(0, 12, (0, [4, 7]))
+    mask.add_request(1, 12, (0, [4, 7]))
+    mask.apply_staged_writes()
+    mapping = torch.tensor([0, 1], device="cuda")
+    positions = torch.tensor([11, 11], device="cuda")
+    logits = torch.full((2, vocab_size), -torch.inf, device="cuda")
+    logits[0, 7] = 2.0
+    logits[1, -1] = 3.0
+    expected = logits.clone()
+    expected[0, 7] = -torch.inf
+    expected[0, 4] = 0.0
+    mask.apply(logits, mapping, np.array([0, 1]), positions)
+    torch.testing.assert_close(logits, expected)


### PR DESCRIPTION
## Summary
Adds support for banning phrases. If a banned string is detected mid-stream, the stream is held back, and continues to hold until the sampler verifies whether it matches the full specified phrase. If not, it releases the held back tokens and continues as normal; if so, the stream is rolled back to right before the first token matching that phrase, and applies a penalty to it then continues. Less concisely:

Assuming the banned phrase is: `a testament to`

| Generated Text | Streaming behavior |
| --- | --- |
| "This is " | Release it |
| "a test" | Hold it: possible phrase beginning |
| "ament " | Continue holding |
| "to" | Phrase detected: rewind | 
| Alternatively, " drive" after "a test" | Release the text once the possibility has been ruled out |

The client keeps "This is ". The matching continuation was never sent, so nothing needs to be retracted. Only that request retries from the rollback boundary, with its failed starting token blocked at that position.

## Usage

**V1 model runner:** Set `APHRODITE_USE_V2_MODEL_RUNNER=0` and `--logits-processors aphrodite.v1.phrase_guard.processor:PhraseRetryProcessor`

**V2 model runner:** Set `--scheduler-cls aphrodite.v1.phrase_guard.scheduler.PhraseScheduler`

You can then send an API request like this:

```sh
curl http://localhost:2242/v1/chat/completions \
    -H 'Content-Type: application/json' \
    -d '{
      "model": "Qwen/Qwen3.5-0.8B",
      "messages": [
        {"role": "user", "content": "Write a short story about an abandoned lighthouse."}
      ],
      "max_tokens": 512,
      "stream": true,
      "aphrodite_xargs": {
        "banned_strings": [
          "a testament to",
          "shivers down",
          "tapestry"
        ],
        "banned_strings_case_sensitive": false
      }
    }'
```

Matching is case-insensitive by default and uses literal substrings across token boundaries. There aren't any regexes or whole-word boundaries, so banning `cat` also catches `cathedral`.

### Current limitations
- V1 NGram GPU spec decoding with pipeline parallelism
- Structured outputs, Mirostat, and token-trace replay
- Multimodal inputs, prompt embeddings, resumable requests, and cache-transfer connectors
- Sampling-mask and routed-expert output