### PR TITLE
fix(exl3): clamp out-of-range expert ids in MoE prefill scatter path

### DIFF
--- a/aphrodite/model_executor/layers/quantization/exl3.py
+++ b/aphrodite/model_executor/layers/quantization/exl3.py
@@ -1120,6 +1120,16 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             dtype=torch.float32,
         )
         flat_expert = topk_ids.reshape(-1)
+        # Route ids outside [0, local_num_experts) — e.g. padding tokens in
+        # the startup memory-profiling dummy batch — into the sentinel bucket
+        # at index local_num_experts instead of scatter_add_ing them out of
+        # bounds below. Mirrors exllamav3's block_sparse_mlp.py reference
+        # (flat_expert_local clamp via torch.where), which this fast/prefill
+        # path lost when the kernels were last synced from upstream.
+        _valid_expert = (flat_expert >= 0) & (flat_expert < layer.local_num_experts)
+        flat_expert = torch.where(
+            _valid_expert, flat_expert, torch.full_like(flat_expert, layer.local_num_experts)
+        )
         flat_weight = topk_weights.reshape(-1)
         flat_token = torch.arange(x_2d.shape[0], device=x_2d.device)
         flat_token = flat_token.repeat_interleave(topk_ids.shape[-1])

--- a/aphrodite/model_executor/layers/quantization/exl3.py
+++ b/aphrodite/model_executor/layers/quantization/exl3.py
@@ -1127,9 +1127,7 @@ class Exl3MoEMethod(FusedMoEMethodBase):
         # (flat_expert_local clamp via torch.where), which this fast/prefill
         # path lost when the kernels were last synced from upstream.
         _valid_expert = (flat_expert >= 0) & (flat_expert < layer.local_num_experts)
-        flat_expert = torch.where(
-            _valid_expert, flat_expert, torch.full_like(flat_expert, layer.local_num_experts)
-        )
+        flat_expert = torch.where(_valid_expert, flat_expert, torch.full_like(flat_expert, layer.local_num_experts))
         flat_weight = topk_weights.reshape(-1)
         flat_token = torch.arange(x_2d.shape[0], device=x_2d.device)
         flat_token = flat_token.repeat_interleave(topk_ids.shape[-1])


### PR DESCRIPTION
## Summary

`Exl3MoEMethod.apply()`'s fast/large-batch forward path builds `expert_count` with size `local_num_experts + 1`, but `scatter_add_`s onto it with the raw `topk_ids` values and no bounds check. Any expert id outside `[0, local_num_experts)` — e.g. from padding tokens in the startup memory-profiling dummy batch — makes the `scatter_add_` write out of bounds:

```
ScatterGatherKernel.cu:203: Assertion `idx_dim >= 0 && idx_dim < index_size && "scatter gather kernel index out of bounds"` failed
torch.AcceleratorError: CUDA error: device-side assert triggered
```

This is deterministic: the built-in memory-profiling pass on startup always exercises this path with a large enough batch, so **any TP EXL3 MoE model fails to boot** on this code path.

## Root cause

exllamav3's own reference implementation (`modules/block_sparse_mlp.py`) guards exactly this case — out-of-range expert ids are clamped via `torch.where` into a sentinel bucket at index `E` (`== local_num_experts`), which the `expert_count` allocation (`E + 1`) already reserves room for. This guard is missing from this fast-batch path.

## Fix

Port the same clamp, reusing the already-allocated sentinel slot — no kernel changes needed.

## Testing

Reproduced and verified the fix on a TP=2 (2×GPU) EXL3 MoE deployment (Qwen3.5-architecture MoE checkpoint, 2.75bpw). Before the fix: engine fails to start every time with the assertion above. After the fix: engine starts and serves requests normally.