### PR TITLE
fix(ci): guard empty commits[@] expansion in reconcile_platform_wheels.sh

### DIFF
--- a/.github/scripts/reconcile_platform_wheels.sh
+++ b/.github/scripts/reconcile_platform_wheels.sh
@@ -181,6 +181,10 @@ echo "Platform: ${PLATFORM_BACKEND}/${PLATFORM_ARCHITECTURE}"
 echo "Last contiguous build: ${last_built:-none}"
 echo "Commits requiring reconciliation: ${#commits[@]}"
 
+# "${commits[@]}" on a genuinely empty array trips "unbound variable" under
+# `set -u` on bash < 4.4 (macOS system /bin/bash is 3.2.57); ${#commits[@]}
+# is safe either way, so gate the loop on the count instead.
+if ((${#commits[@]} > 0)); then
 for commit in "${commits[@]}"; do
   restore_tracked_build_changes
   git checkout --detach "$commit"
@@ -229,6 +233,7 @@ for commit in "${commits[@]}"; do
 
   printf '%s\n' "$commit" | "$rclone" rcat "$state_remote"
 done
+fi
 
 restore_tracked_build_changes
 git checkout --detach "$target_commit"


### PR DESCRIPTION
## Summary
The Metal nightly (Apple Silicon) job has failed every run since 2026-08-18 with:

\`\`\`
.github/scripts/reconcile_platform_wheels.sh: line 231: commits[@]: unbound variable
\`\`\`

Still reproducing as of today's run (2026-09-11, run 34578149399) — closes #1768.

## Root cause
The script runs with \`set -euo pipefail\`. When there are zero commits to reconcile, \`commits=()\` stays a genuinely empty array. \`\${commits[@]}\` (the array itself, as opposed to \`\${#commits[@]}\`, the count) triggers "unbound variable" under \`set -u\` on bash < 4.4. macOS ships bash 3.2.57 as \`/bin/bash\`, which the script's \`#!/usr/bin/env bash\` shebang picks up on the Metal runner.

This only manifests when there is nothing new to build, which is why it went unnoticed on other platforms that usually have something to reconcile.

## Fix
Gate the loop on \`\${#commits[@]}\`, which is always safe to expand, instead of touching \`\${commits[@]}\` when it may be empty.

Fixes #1768

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G44KU7EBqqzdfE85y78gda