### PR TITLE
chore: change aphrodite ascii art to sonar

### DIFF
--- a/aphrodite/entrypoints/serve/utils/api_utils.py
+++ b/aphrodite/entrypoints/serve/utils/api_utils.py
@@ -306,21 +306,23 @@ def log_version_and_model(lgr: Logger, version: str, model_name: str) -> None:
 
     logo_template = Template(
         "\n"
-        "${w}     ▗▄▄▖ ▗▄▖ ▗▖  ▗▖ ▗▄▖ ▗▄▄▖${r}\n"
-        "${w}    ▐▌   ▐▌ ▐▌▐▛▚▖▐▌▐▌ ▐▌▐▌ ▐▌${r}\n"
-        "${w}     ▝▀▚▖▐▌ ▐▌▐▌ ▝▜▌▐▛▀▜▌▐▛▀▚▖${r}\n"
-        "${w}    ▗▄▄▞▘▝▚▄▞▘▐▌  ▐▌▐▌ ▐▌▐▌ ▐▌${r}\n"
+        "${w} ▗▄▄▖ ▗▄▖ ▗▖  ▗▖ ▗▄▖ ▗▄▄▖${r}\n"
+        "${w}▐▌   ▐▌ ▐▌▐▛▚▖▐▌▐▌ ▐▌▐▌ ▐▌${r}\n"
+        "${w} ▝▀▚▖▐▌ ▐▌▐▌ ▝▜▌▐▛▀▜▌▐▛▀▚▖${r}\n"
+        "${w}▗▄▄▞▘▝▚▄▞▘▐▌  ▐▌▐▌ ▐▌▐▌ ▐▌${r}\n"
     )
     colors = {"w": "\033[1m", "r": "\033[0m"}  # bold default foreground, reset
     if formatter != "color":
         # monochrome logo (no ansi escape codes)
         colors = dict.fromkeys(colors, "")
 
-    logo = logo_template.substitute(colors)
-    width = max(len(line) for line in logo_template.substitute(w="", r="").splitlines())
-    version_line = f"version: {version}".center(width)
-    model_line = f"model: {model_name}".center(width)
-    lgr.info("%s\n%s\n%s\n", logo, version_line, model_line)
+    version_line = f"version: {version}"
+    model_line = f"model: {model_name}"
+    logo_width = max(map(len, logo_template.substitute(w="", r="").splitlines()))
+    width = max(logo_width, len(version_line), len(model_line))
+    padding = " " * ((width - logo_width) // 2)
+    logo = logo_template.substitute(w=padding + colors["w"], r=colors["r"])
+    lgr.info("%s\n%s\n%s\n", logo, version_line.center(width), model_line.center(width))
 
 
 async def validate_json_request(raw_request: Request):

--- a/aphrodite/entrypoints/serve/utils/api_utils.py
+++ b/aphrodite/entrypoints/serve/utils/api_utils.py
@@ -306,9 +306,10 @@ def log_version_and_model(lgr: Logger, version: str, model_name: str) -> None:
 
     logo_template = Template(
         "\n"
-        "${w}     ▄▄▄  ▄▄▄▄  ▄▄ ▄▄ ▄▄▄▄   ▄▄▄  ▄▄▄▄  ▄▄ ▄▄▄▄▄▄ ▄▄▄▄▄${r}\n"
-        "${w}    ██▀██ ██▄█▀ ██▄██ ██▄█▄ ██▀██ ██▀██ ██   ██   ██▄▄${r}\n"
-        "${w}    ██▀██ ██    ██ ██ ██ ██ ▀███▀ ████▀ ██   ██   ██▄▄▄${r}\n"
+        "${w}     ▗▄▄▖ ▗▄▖ ▗▖  ▗▖ ▗▄▖ ▗▄▄▖${r}\n"
+        "${w}    ▐▌   ▐▌ ▐▌▐▛▚▖▐▌▐▌ ▐▌▐▌ ▐▌${r}\n"
+        "${w}     ▝▀▚▖▐▌ ▐▌▐▌ ▝▜▌▐▛▀▜▌▐▛▀▚▖${r}\n"
+        "${w}    ▗▄▄▞▘▝▚▄▞▘▐▌  ▐▌▐▌ ▐▌▐▌ ▐▌${r}\n"
     )
     colors = {"w": "\033[1m", "r": "\033[0m"}  # bold default foreground, reset
     if formatter != "color":
@@ -316,7 +317,7 @@ def log_version_and_model(lgr: Logger, version: str, model_name: str) -> None:
         colors = dict.fromkeys(colors, "")
 
     logo = logo_template.substitute(colors)
-    width = 54  # logo art width
+    width = max(len(line) for line in logo_template.substitute(w="", r="").splitlines())
     version_line = f"version: {version}".center(width)
     model_line = f"model: {model_name}".center(width)
     lgr.info("%s\n%s\n%s\n", logo, version_line, model_line)

--- a/aphrodite/entrypoints/utils.py
+++ b/aphrodite/entrypoints/utils.py
@@ -7,20 +7,18 @@ import functools
 import os
 from argparse import Namespace
 from http import HTTPStatus
-from logging import Logger
 
 import regex as re
 from fastapi import Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.background import BackgroundTask, BackgroundTasks
 
-from aphrodite import envs
 from aphrodite.engine.arg_utils import EngineArgs
 from aphrodite.entrypoints.generate.base.protocol import StreamOptions
 from aphrodite.entrypoints.openai.models.protocol import LoRAModulePath
 from aphrodite.entrypoints.serve.engine.protocol import ErrorInfo, ErrorResponse
 from aphrodite.exceptions import GenerationError
-from aphrodite.logger import current_formatter_type, init_logger
+from aphrodite.logger import init_logger
 from aphrodite.platforms import current_platform
 from aphrodite.utils.argparse_utils import FlexibleArgumentParser
 
@@ -255,25 +253,6 @@ def sanitize_message(message: str) -> str:
     message = re.sub(r"/(?:home|usr|opt|var|tmp|root|lib|mnt|srv)(?:/[\w.\-]+)+", "<path>", message)
     message = re.sub(r"(?:/[\w\-]+)+/[\w\-]+\.\w+", "<path>", message)
     return message.strip()
-
-
-def log_version_and_model(lgr: Logger, version: str, model_name: str) -> None:
-    logo = r"""                                                                          
-     ▄▄▄  ▄▄▄▄  ▄▄ ▄▄ ▄▄▄▄   ▄▄▄  ▄▄▄▄  ▄▄ ▄▄▄▄▄▄ ▄▄▄▄▄ 
-    ██▀██ ██▄█▀ ██▄██ ██▄█▄ ██▀██ ██▀██ ██   ██   ██▄▄  
-    ██▀██ ██    ██ ██ ██ ██ ▀███▀ ████▀ ██   ██   ██▄▄▄ 
-                                                                                                   
-    """
-    if envs.APHRODITE_DISABLE_LOG_LOGO or current_formatter_type(lgr) is None:
-        message = "Aphrodite server version %s, serving model %s"
-        lgr.info(message, version, model_name)
-    else:
-        logo_lines = logo.splitlines()
-        logo_width = max((len(line.rstrip()) for line in logo_lines if line.strip()), default=0)
-        version_line = f"version: {version}".center(logo_width)
-        model_line = f"model: {model_name}".center(logo_width)
-        message = f"\n{logo}\n{version_line}\n{model_line}\n"
-        lgr.info("%s", message)
 
 
 def create_error_response(


### PR DESCRIPTION
few notes:
- regular utils.py logo output didnt seem to be in use anywhere (and drifted?); removed it
- changed api_utils hardcoded width to use the same dynamic width calc old utils.py did
- I did not run full aphrodite to confirm the ascii art doesn't now height shift other log lines; but outputting it with dummy data looks identical, now just taking up 1 more line of height